### PR TITLE
Upgrade compose-highlight to 0.8.0 and update SDK targets to 36

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 # Android SDK versions
 # https://developer.android.com/about/versions
-compileSdk = "37"
-targetSdk = "37"
+compileSdk = "36"
+targetSdk = "36"
 minSdk = "28"
 
 activityCompose = "1.13.0"
@@ -100,7 +100,7 @@ shiki-sdk = { group = "com.github.hossain-khan.shiki-token-service", name = "sdk
 
 # compose-highlight - on-device syntax highlighting via Highlight.js WebView
 # https://github.com/hossain-khan/android-compose-highlight
-compose-highlight = { group = "com.github.hossain-khan", name = "android-compose-highlight", version = "0.5.0" }
+compose-highlight = { group = "com.github.hossain-khan", name = "android-compose-highlight", version = "0.8.0" }
 
 # kotlin-textmate transitive dependencies (required by core.jar local library)
 # https://github.com/ivan-magda/kotlin-textmate


### PR DESCRIPTION
## Changes

- **Upgrade compose-highlight** from 0.5.0 to 0.8.0
  - v0.6.0: Shared WebView (saves ~200ms + 2-4MB per block), line number alignment fix
  - v0.7.0: Custom copy button icons, caller-owned copy feedback, new language samples
  - v0.8.0: Target SDK update (37 → 36)

- **Update SDK versions** from 37 to 36 (aligned with library requirements)

## Build Status
✅ Build successful - all tests pass, APK builds without errors