### PR TITLE
Upgrade compose-highlight to 0.9.0 + lib updates

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,20 +8,20 @@ minSdk = "28"
 activityCompose = "1.13.0"
 # https://developer.android.com/build/releases/gradle-plugin
 # AGP 9.1 requires Gradle 9.3.1 or higher
-agp = "9.1.1"
+agp = "9.2.1"
 circuit = "0.33.1"
-composeBom = "2026.03.01"
+composeBom = "2026.05.00"
 coreKtx = "1.18.0"
 espressoCore = "3.7.0"
-googleFonts = "1.10.6"
+googleFonts = "1.11.1"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 
 # https://kotlinlang.org/docs/releases.html
-kotlin = "2.3.20"
+kotlin = "2.3.21"
 # The KSP (Kotlin Symbol Processing) plugin version is managed separately in this template.
 # When upgrading Kotlin or KSP, verify that the selected KSP release is compatible with the configured Kotlin version.
-ksp = "2.3.6"
+ksp = "2.3.7"
 
 # Networking
 # https://square.github.io/okhttp/
@@ -33,10 +33,10 @@ kotlinxSerializationJson = "1.11.0"
 # https://github.com/JakeWharton/retrofit2-kotlinx-serialization-converter
 retrofitKotlinxSerializationConverter = "1.0.0"
 
-joni = "2.2.1"
-jcodings = "1.0.58"
+joni = "2.2.7"
+jcodings = "1.0.64"
 # https://github.com/google/gson
-gson = "2.11.0"
+gson = "2.14.0"
 
 # Kotlin linter with built-in formatter
 # https://github.com/jeremymailen/kotlinter-gradle

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -100,7 +100,7 @@ shiki-sdk = { group = "com.github.hossain-khan.shiki-token-service", name = "sdk
 
 # compose-highlight - on-device syntax highlighting via Highlight.js WebView
 # https://github.com/hossain-khan/android-compose-highlight
-compose-highlight = { group = "com.github.hossain-khan", name = "android-compose-highlight", version = "0.8.0" }
+compose-highlight = { group = "com.github.hossain-khan", name = "android-compose-highlight", version = "0.9.0" }
 
 # kotlin-textmate transitive dependencies (required by core.jar local library)
 # https://github.com/ivan-magda/kotlin-textmate


### PR DESCRIPTION
## Changes

- **Upgrade compose-highlight** from 0.8.0 to 0.9.0

### Breaking Changes in Library
- `SyntaxHighlightedCode` component now uses `CodeBlockStyle.textStyle` instead of separate `fontFamily`, `fontSize`, `lineHeight` parameters
- New: `SyntaxHighlightedCodeDefaults` exposes all default values

### Impact on This App
✅ **No code changes required** — This app uses the lower-level `rememberHighlightedCodeBothThemes` API which returns an `AnnotatedString`, not the `SyntaxHighlightedCode` component directly.

## Build Status
✅ Build successful - all tests pass, APK builds without errors