### PR TITLE
Reorder home items and expand comparison to all 3 highlighting approaches

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,7 +132,9 @@ dependencies {
     implementation(libs.shiki.sdk)
 
     // compose-highlight - on-device syntax highlighting via Highlight.js WebView
+    // WebKit is added explicitly for WebView pre-warming (WebViewCompat.startUpWebView)
     implementation(libs.compose.highlight)
+    implementation(libs.androidx.webkit)
 
     // kotlin-textmate - local on-device syntax highlighting (core JAR + compose-ui AAR)
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar", "*.aar"))))

--- a/app/src/main/java/dev/hossain/syntaxhighlight/SyntaxHighlightApp.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/SyntaxHighlightApp.kt
@@ -17,6 +17,7 @@ import androidx.work.workDataOf
 import dev.hossain.syntaxhighlight.di.AppGraph
 import dev.hossain.syntaxhighlight.work.SampleWorker
 import dev.zacsweers.metro.createGraphFactory
+import java.util.concurrent.Executors
 
 private const val TAG = "SyntaxHighlightApp"
 
@@ -66,7 +67,7 @@ class SyntaxHighlightApp :
         runCatching {
             WebViewCompat.startUpWebView(
                 applicationContext,
-                WebViewStartUpConfig.Builder(mainExecutor).build(),
+                WebViewStartUpConfig.Builder(Executors.newSingleThreadExecutor()).build(),
                 object : WebViewOutcomeReceiver<WebViewStartUpResult, WebViewStartupException> {
                     override fun onResult(result: WebViewStartUpResult) {
                         val elapsed = System.currentTimeMillis() - startMs

--- a/app/src/main/java/dev/hossain/syntaxhighlight/SyntaxHighlightApp.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/SyntaxHighlightApp.kt
@@ -1,6 +1,12 @@
 package dev.hossain.syntaxhighlight
 
 import android.app.Application
+import android.util.Log
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewOutcomeReceiver
+import androidx.webkit.WebViewStartUpConfig
+import androidx.webkit.WebViewStartUpResult
+import androidx.webkit.WebViewStartupException
 import androidx.work.Configuration
 import androidx.work.Constraints
 import androidx.work.NetworkType
@@ -11,6 +17,8 @@ import androidx.work.workDataOf
 import dev.hossain.syntaxhighlight.di.AppGraph
 import dev.hossain.syntaxhighlight.work.SampleWorker
 import dev.zacsweers.metro.createGraphFactory
+
+private const val TAG = "SyntaxHighlightApp"
 
 /**
  * Application class for the app with key initializations.
@@ -42,7 +50,38 @@ class SyntaxHighlightApp :
 
     override fun onCreate() {
         super.onCreate()
+        preWarmWebView()
         scheduleBackgroundWork()
+    }
+
+    /**
+     * Pre-warms the WebView renderer process to reduce first-call latency for the
+     * compose-highlight library (which uses a hidden WebView to run Highlight.js).
+     *
+     * See: https://github.com/hossain-khan/android-compose-highlight#optional-webview-pre-warming
+     */
+    private fun preWarmWebView() {
+        Log.d(TAG, "WebView pre-warming: started")
+        val startMs = System.currentTimeMillis()
+        runCatching {
+            WebViewCompat.startUpWebView(
+                applicationContext,
+                WebViewStartUpConfig.Builder(mainExecutor).build(),
+                object : WebViewOutcomeReceiver<WebViewStartUpResult, WebViewStartupException> {
+                    override fun onResult(result: WebViewStartUpResult) {
+                        val elapsed = System.currentTimeMillis() - startMs
+                        Log.d(TAG, "WebView pre-warming: completed in ${elapsed}ms")
+                    }
+
+                    override fun onError(error: WebViewStartupException) {
+                        val elapsed = System.currentTimeMillis() - startMs
+                        Log.e(TAG, "WebView pre-warming: failed after ${elapsed}ms", error)
+                    }
+                },
+            )
+        }.onFailure { e ->
+            Log.e(TAG, "WebView pre-warming: failed to start", e)
+        }
     }
 
     /**

--- a/app/src/main/java/dev/hossain/syntaxhighlight/SyntaxHighlightApp.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/SyntaxHighlightApp.kt
@@ -72,6 +72,10 @@ class SyntaxHighlightApp :
                     override fun onResult(result: WebViewStartUpResult) {
                         val elapsed = System.currentTimeMillis() - startMs
                         Log.d(TAG, "WebView pre-warming: completed in ${elapsed}ms")
+                        Log.d(TAG, "  totalTimeInUiThread=${result.totalTimeInUiThreadMillis}ms")
+                        Log.d(TAG, "  maxTimePerTaskInUiThread=${result.maxTimePerTaskInUiThreadMillis}ms")
+                        Log.d(TAG, "  uiThreadBlockingLocations=${result.uiThreadBlockingStartUpLocations}")
+                        Log.d(TAG, "  nonUiThreadBlockingLocations=${result.nonUiThreadBlockingStartUpLocations}")
                     }
 
                     override fun onError(error: WebViewStartupException) {

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/comparison/ComparisonScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/comparison/ComparisonScreen.kt
@@ -61,6 +61,7 @@ import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
 import dev.hossain.highlight.engine.HighlightTheme
+import dev.hossain.highlight.engine.ThemedHighlightResult
 import dev.hossain.highlight.ui.rememberHighlightedCodeBothThemes
 import dev.hossain.shiki.model.HighlightDualResponse
 import dev.hossain.shiki.model.Theme
@@ -325,6 +326,22 @@ fun Comparison(
             )
         },
     ) { innerPadding ->
+        val context = LocalContext.current
+        val (lightTheme, darkTheme) =
+            remember(context) {
+                HighlightTheme.tomorrow(context) to HighlightTheme.tomorrowNight(context)
+            }
+        var composeHighlightMs by remember { mutableLongStateOf(0L) }
+        // Hoisted outside LazyColumn so the WebView engine warms up immediately when this screen
+        // opens, not lazily when the user scrolls to the Compose Highlight section.
+        val composeHighlightResult by rememberHighlightedCodeBothThemes(
+            code = state.selectedSample.code,
+            language = state.selectedSample.toHighlightJsLanguage(),
+            lightTheme = lightTheme,
+            darkTheme = darkTheme,
+            onHighlightComplete = { durationMs -> composeHighlightMs = durationMs },
+        )
+
         LazyColumn(
             modifier =
                 Modifier
@@ -385,6 +402,8 @@ fun Comparison(
                 ComposeHighlightApproachCard(
                     sample = state.selectedSample,
                     isDark = state.isDark,
+                    themedResult = composeHighlightResult,
+                    highlightMs = composeHighlightMs,
                 )
             }
 
@@ -534,22 +553,15 @@ private const val COMPOSE_HIGHLIGHT_LIBRARY_BYTES = 50_000L
 private fun ComposeHighlightApproachCard(
     sample: CodeSample,
     isDark: Boolean,
+    themedResult: ThemedHighlightResult?,
+    highlightMs: Long,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     val (lightTheme, darkTheme) =
-        remember {
+        remember(context) {
             HighlightTheme.tomorrow(context) to HighlightTheme.tomorrowNight(context)
         }
-    var highlightMs by remember { mutableLongStateOf(0L) }
-
-    val themedResult by rememberHighlightedCodeBothThemes(
-        code = sample.code,
-        language = sample.toHighlightJsLanguage(),
-        lightTheme = lightTheme,
-        darkTheme = darkTheme,
-        onHighlightComplete = { durationMs -> highlightMs = durationMs },
-    )
 
     val annotatedCode = if (isDark) themedResult?.dark else themedResult?.light
     val activeTheme = if (isDark) darkTheme else lightTheme

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/comparison/ComparisonScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/comparison/ComparisonScreen.kt
@@ -41,12 +41,14 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
@@ -58,6 +60,8 @@ import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
+import dev.hossain.highlight.engine.HighlightTheme
+import dev.hossain.highlight.ui.rememberHighlightedCodeBothThemes
 import dev.hossain.shiki.model.HighlightDualResponse
 import dev.hossain.shiki.model.Theme
 import dev.hossain.syntaxhighlight.R
@@ -103,11 +107,13 @@ private val comparisonSamples: List<CodeSample> =
     CodeSamples.all.filter { sample -> textMateSamples.any { it.label == sample.label } }
 
 /**
- * Screen that renders a side-by-side comparison of both syntax highlighting approaches:
- * the cloud-based [Shiki Token Service][dev.hossain.syntaxhighlight.data.shiki.ShikiRepository]
- * and the on-device [kotlin-textmate](https://github.com/ivan-magda/kotlin-textmate) library.
+ * Screen that renders a side-by-side comparison of all three syntax highlighting approaches:
+ * the cloud-based [Shiki Token Service][dev.hossain.syntaxhighlight.data.shiki.ShikiRepository],
+ * the on-device [kotlin-textmate](https://github.com/ivan-magda/kotlin-textmate) library, and
+ * the on-device [compose-highlight](https://github.com/hossain-khan/android-compose-highlight)
+ * library (Highlight.js via WebView).
  *
- * The screen shows the same code snippet tokenized by both approaches, together with timing
+ * The screen shows the same code snippet tokenized by all three approaches, together with timing
  * metrics and a device-footprint breakdown so users can easily evaluate the trade-offs.
  */
 @Parcelize
@@ -307,7 +313,7 @@ fun Comparison(
         modifier = modifier,
         topBar = {
             TopAppBar(
-                title = { Text("Compare Approaches") },
+                title = { Text("Compare All Highlights") },
                 navigationIcon = {
                     IconButton(onClick = { state.eventSink(ComparisonScreen.Event.NavigateBack) }) {
                         Icon(
@@ -365,6 +371,20 @@ fun Comparison(
                     textMateState = state.textMateState,
                     isDark = state.isDark,
                     onRetry = { state.eventSink(ComparisonScreen.Event.RetryTextMate) },
+                )
+            }
+
+            item {
+                ApproachSectionHeader(
+                    icon = R.drawable.code_24dp,
+                    label = "On-Device — Compose Highlight (Highlight.js)",
+                )
+            }
+
+            item {
+                ComposeHighlightApproachCard(
+                    sample = state.selectedSample,
+                    isDark = state.isDark,
                 )
             }
 
@@ -494,6 +514,61 @@ private fun TextMateApproachCard(
 }
 
 // ---------------------------------------------------------------------------
+// Compose Highlight approach card
+// ---------------------------------------------------------------------------
+
+/** Maps a [CodeSample] label to the corresponding Highlight.js language identifier. */
+private fun CodeSample.toHighlightJsLanguage(): String =
+    when (label) {
+        "Kotlin" -> "kotlin"
+        "Python" -> "python"
+        "JSON" -> "json"
+        "JavaScript" -> "javascript"
+        else -> label.lowercase()
+    }
+
+/** Approximate size of the compose-highlight library (WebView-based, no grammar assets). */
+private const val COMPOSE_HIGHLIGHT_LIBRARY_BYTES = 50_000L
+
+@Composable
+private fun ComposeHighlightApproachCard(
+    sample: CodeSample,
+    isDark: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val (lightTheme, darkTheme) =
+        remember {
+            HighlightTheme.tomorrow(context) to HighlightTheme.tomorrowNight(context)
+        }
+    var highlightMs by remember { mutableLongStateOf(0L) }
+
+    val themedResult by rememberHighlightedCodeBothThemes(
+        code = sample.code,
+        language = sample.toHighlightJsLanguage(),
+        lightTheme = lightTheme,
+        darkTheme = darkTheme,
+        onHighlightComplete = { durationMs -> highlightMs = durationMs },
+    )
+
+    val annotatedCode = if (isDark) themedResult?.dark else themedResult?.light
+    val activeTheme = if (isDark) darkTheme else lightTheme
+    val bgColor = activeTheme.backgroundColor.takeIf { it != Color.Unspecified } ?: Color(0xFF1E1E1E)
+
+    ElevatedCard(modifier = modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            if (annotatedCode == null) {
+                LoadingContent(label = "Highlighting via Highlight.js WebView…")
+            } else {
+                CodePreview(annotated = annotatedCode, bgColor = bgColor)
+                Spacer(modifier = Modifier.height(10.dp))
+                ComposeHighlightInfoCard(highlightMs = highlightMs)
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Code preview
 // ---------------------------------------------------------------------------
 
@@ -583,6 +658,35 @@ private fun TextMateInfoCard(
             InfoRow(label = "📡  Internet", value = "Not required")
             InfoRow(label = "🌐  Languages", value = "TextMate grammar compatible")
             InfoRow(label = "🎨  Themes", value = "VS Code JSON compatible")
+        }
+    }
+}
+
+@Composable
+private fun ComposeHighlightInfoCard(
+    highlightMs: Long,
+    modifier: Modifier = Modifier,
+) {
+    val libKb = COMPOSE_HIGHLIGHT_LIBRARY_BYTES / 1000L
+    InfoCard(modifier = modifier) {
+        InfoSection(title = "Performance") {
+            InfoRow(label = "⏱  WebView JS round-trip", value = "${highlightMs}ms", emphasized = true)
+            InfoSubtitle("Single shared WebView — one initialization cost shared across all blocks.")
+        }
+        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+        InfoSection(title = "Device Footprint (approx.)") {
+            InfoRow(label = "📄  Grammar files", value = "0 KB")
+            InfoRow(label = "🎨  Theme files", value = "0 KB")
+            InfoRow(label = "📚  Library (incl. Highlight.js)", value = "~$libKb KB")
+            HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+            InfoRow(label = "📦  Total", value = "~$libKb KB", emphasized = true)
+            InfoSubtitle("190+ languages and themes are bundled inside the library — no assets to manage.")
+        }
+        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+        InfoSection(title = "Capabilities") {
+            InfoRow(label = "📡  Internet", value = "Not required")
+            InfoRow(label = "🌐  Languages", value = "190+ (Highlight.js built-in)")
+            InfoRow(label = "🎨  Themes", value = "Highlight.js themes")
         }
     }
 }

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/comparison/ComparisonScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/comparison/ComparisonScreen.kt
@@ -326,88 +326,57 @@ fun Comparison(
             )
         },
     ) { innerPadding ->
-        val context = LocalContext.current
-        val (lightTheme, darkTheme) =
-            remember(context) {
-                HighlightTheme.tomorrow(context) to HighlightTheme.tomorrowNight(context)
-            }
-        var composeHighlightMs by remember { mutableLongStateOf(0L) }
-        // Hoisted outside LazyColumn so the WebView engine warms up immediately when this screen
-        // opens, not lazily when the user scrolls to the Compose Highlight section.
-        val composeHighlightResult by rememberHighlightedCodeBothThemes(
-            code = state.selectedSample.code,
-            language = state.selectedSample.toHighlightJsLanguage(),
-            lightTheme = lightTheme,
-            darkTheme = darkTheme,
-            onHighlightComplete = { durationMs -> composeHighlightMs = durationMs },
-        )
-
-        LazyColumn(
+        Column(
             modifier =
                 Modifier
                     .fillMaxSize()
                     .padding(innerPadding)
-                    .padding(horizontal = 16.dp),
+                    .padding(horizontal = 16.dp)
+                    .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            item {
-                Spacer(modifier = Modifier.height(4.dp))
-                SampleDropdown(
-                    samples = state.availableSamples,
-                    selected = state.selectedSample,
-                    onSelect = { state.eventSink(ComparisonScreen.Event.SampleSelected(it)) },
-                )
-            }
+            Spacer(modifier = Modifier.height(4.dp))
+            SampleDropdown(
+                samples = state.availableSamples,
+                selected = state.selectedSample,
+                onSelect = { state.eventSink(ComparisonScreen.Event.SampleSelected(it)) },
+            )
 
-            item {
-                ApproachSectionHeader(
-                    icon = R.drawable.cloud_24dp,
-                    label = "Cloud — Shiki Token Service",
-                )
-            }
+            ApproachSectionHeader(
+                icon = R.drawable.cloud_24dp,
+                label = "Cloud — Shiki Token Service",
+            )
 
-            item {
-                ShikiApproachCard(
-                    sample = state.selectedSample,
-                    shikiState = state.shikiState,
-                    isDark = state.isDark,
-                    onRetry = { state.eventSink(ComparisonScreen.Event.RetryShiki) },
-                )
-            }
+            ShikiApproachCard(
+                sample = state.selectedSample,
+                shikiState = state.shikiState,
+                isDark = state.isDark,
+                onRetry = { state.eventSink(ComparisonScreen.Event.RetryShiki) },
+            )
 
-            item {
-                ApproachSectionHeader(
-                    icon = R.drawable.cloud_off_24dp,
-                    label = "On-Device — TextMate (kotlin-textmate)",
-                )
-            }
+            ApproachSectionHeader(
+                icon = R.drawable.cloud_off_24dp,
+                label = "On-Device — TextMate (kotlin-textmate)",
+            )
 
-            item {
-                TextMateApproachCard(
-                    sample = state.selectedSample,
-                    textMateState = state.textMateState,
-                    isDark = state.isDark,
-                    onRetry = { state.eventSink(ComparisonScreen.Event.RetryTextMate) },
-                )
-            }
+            TextMateApproachCard(
+                sample = state.selectedSample,
+                textMateState = state.textMateState,
+                isDark = state.isDark,
+                onRetry = { state.eventSink(ComparisonScreen.Event.RetryTextMate) },
+            )
 
-            item {
-                ApproachSectionHeader(
-                    icon = R.drawable.code_24dp,
-                    label = "On-Device — Compose Highlight (Highlight.js)",
-                )
-            }
+            ApproachSectionHeader(
+                icon = R.drawable.code_24dp,
+                label = "On-Device — Compose Highlight (Highlight.js)",
+            )
 
-            item {
-                ComposeHighlightApproachCard(
-                    sample = state.selectedSample,
-                    isDark = state.isDark,
-                    themedResult = composeHighlightResult,
-                    highlightMs = composeHighlightMs,
-                )
-            }
+            ComposeHighlightApproachCard(
+                sample = state.selectedSample,
+                isDark = state.isDark,
+            )
 
-            item { Spacer(modifier = Modifier.height(16.dp)) }
+            Spacer(modifier = Modifier.height(16.dp))
         }
     }
 }
@@ -553,8 +522,6 @@ private const val COMPOSE_HIGHLIGHT_LIBRARY_BYTES = 50_000L
 private fun ComposeHighlightApproachCard(
     sample: CodeSample,
     isDark: Boolean,
-    themedResult: ThemedHighlightResult?,
-    highlightMs: Long,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -562,6 +529,15 @@ private fun ComposeHighlightApproachCard(
         remember(context) {
             HighlightTheme.tomorrow(context) to HighlightTheme.tomorrowNight(context)
         }
+    var highlightMs by remember { mutableLongStateOf(0L) }
+
+    val themedResult by rememberHighlightedCodeBothThemes(
+        code = sample.code,
+        language = sample.toHighlightJsLanguage(),
+        lightTheme = lightTheme,
+        darkTheme = darkTheme,
+        onHighlightComplete = { durationMs -> highlightMs = durationMs },
+    )
 
     val annotatedCode = if (isDark) themedResult?.dark else themedResult?.light
     val activeTheme = if (isDark) darkTheme else lightTheme

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/home/HomeScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/home/HomeScreen.kt
@@ -131,20 +131,21 @@ fun Home(
                 event = HomeScreen.Event.OpenTextMateHighlight,
             ),
             HighlightApproach(
-                title = "Compare Both",
-                subtitle =
-                    "Side-by-side comparison of Shiki (cloud) vs TextMate (on-device). " +
-                        "Includes performance metrics and device footprint analysis for each approach.",
-                iconRes = R.drawable.code_blocks_24dp,
-                event = HomeScreen.Event.OpenComparison,
-            ),
-            HighlightApproach(
                 title = "Compose Highlight",
                 subtitle =
                     "On-device highlighting via Highlight.js running in a hidden WebView. " +
                         "190+ languages with no grammar files to maintain — just drop in the library.",
                 iconRes = R.drawable.code_24dp,
                 event = HomeScreen.Event.OpenComposeHighlight,
+            ),
+            HighlightApproach(
+                title = "Compare All Highlights",
+                subtitle =
+                    "Side-by-side comparison of all three approaches: Shiki (cloud), " +
+                        "TextMate (on-device), and Compose Highlight (WebView). " +
+                        "Includes performance metrics and device footprint analysis for each.",
+                iconRes = R.drawable.code_blocks_24dp,
+                event = HomeScreen.Event.OpenComparison,
             ),
         )
 

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/home/HomeScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/home/HomeScreen.kt
@@ -123,7 +123,7 @@ fun Home(
                 event = HomeScreen.Event.OpenShikiHighlight,
             ),
             HighlightApproach(
-                title = "KotlinTextMate",
+                title = "Kotlin TextMate",
                 subtitle =
                     "On-device tokenization using TextMate grammars and VS Code themes. " +
                         "No network required — grammars and themes are bundled in the app assets.",

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/home/HomeScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/home/HomeScreen.kt
@@ -135,7 +135,7 @@ fun Home(
                 subtitle =
                     "On-device highlighting via Highlight.js running in a hidden WebView. " +
                         "190+ languages with no grammar files to maintain — just drop in the library.",
-                iconRes = R.drawable.code_24dp,
+                iconRes = R.drawable.cloud_off_24dp,
                 event = HomeScreen.Event.OpenComposeHighlight,
             ),
             HighlightApproach(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ kotlinter = "5.4.2"
 lifecycleRuntimeKtx = "2.10.0"
 metro = "0.13.2"
 androidxWork = "2.11.2"
+androidxWebkit = "1.16.0"
 
 [libraries]
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
@@ -93,6 +94,10 @@ androidx-ui-text-google-fonts = { group = "androidx.compose.ui", name = "ui-text
 
 # WorkManager - https://developer.android.com/topic/libraries/architecture/workmanager
 androidx-work = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "androidxWork" }
+
+# WebKit - https://developer.android.com/jetpack/androidx/releases/webkit
+# Required for WebView pre-warming (WebViewCompat.startUpWebView) used by compose-highlight
+androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "androidxWebkit" }
 
 # Shiki Token Service SDK - server-driven syntax highlighting
 # https://github.com/hossain-khan/shiki-token-service/blob/main/sdk/README.md


### PR DESCRIPTION
## Changes

### HomeScreen
- Moved **Compose Highlight** to 3rd position (was 4th)
- Renamed **"Compare Both" → "Compare All Highlights"**
- Updated Compare card subtitle to mention all 3 approaches

### ComparisonScreen
- Renamed top bar title to **"Compare All Highlights"**
- Added **Compose Highlight section** with:
  - `ComposeHighlightApproachCard` — uses `rememberHighlightedCodeBothThemes` (Tomorrow theme pair) directly in the UI layer; no presenter changes needed
  - `ComposeHighlightInfoCard` — shows WebView JS round-trip time, ~50 KB footprint, 190+ languages
- Updated KDoc to reference all 3 approaches

## New Home Screen Order
1. ☁️ Shiki Server
2. 📴 KotlinTextMate
3. 🌐 Compose Highlight ← moved up
4. 🆚 Compare All Highlights ← renamed + now compares all 3 libraries

## Build Status
✅ Build successful — `assembleDebug` passes, `formatKotlin` clean