### PR TITLE
chore: migrate Metro to 1.0.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -162,11 +162,6 @@ metro {
     // Enable Metro's built-in Circuit codegen support (introduced in Metro 0.13.0).
     // This replaces the circuit-codegen KSP processor and the circuit.codegen.mode=metro KSP arg.
     // See https://zacsweers.github.io/metro/latest/circuit/
-    enableCircuitCodegen.set(true)
-
-    // Shrink unused bindings to reduce generated code size (delicate API in Metro 0.11+)
-    // This is a delicate API - use with caution in large dependency graphs
-    // See https://zacsweers.github.io/metro/latest/dependency-graphs/
     @Suppress("DelicateApi")
-    shrinkUnusedBindings.set(true)
+    enableCircuitCodegen.set(true)
 }

--- a/app/src/main/java/dev/hossain/syntaxhighlight/di/AppGraph.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/di/AppGraph.kt
@@ -6,7 +6,7 @@ import com.slack.circuit.foundation.Circuit
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Multibinds
-import dev.zacsweers.metro.Provider
+import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
 import kotlin.reflect.KClass
 
@@ -39,7 +39,7 @@ interface AppGraph {
      * See https://zacsweers.github.io/metro/latest/bindings/#multibindings
      */
     @Multibinds
-    val activityProviders: Map<KClass<out Activity>, Provider<Activity>>
+    val activityProviders: Map<KClass<out Activity>, () -> Activity>
 
     /**
      * Circuit instance for handling UI presentation and state management.

--- a/app/src/main/java/dev/hossain/syntaxhighlight/di/ComposeAppComponentFactory.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/di/ComposeAppComponentFactory.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import androidx.annotation.Keep
 import androidx.core.app.AppComponentFactory
 import dev.hossain.syntaxhighlight.SyntaxHighlightApp
-import dev.zacsweers.metro.Provider
 import kotlin.reflect.KClass
 
 /**
@@ -57,7 +56,7 @@ class ComposeAppComponentFactory : AppComponentFactory() {
     private inline fun <reified T : Any> getInstance(
         classLoader: ClassLoader,
         className: String,
-        providers: Map<KClass<out T>, Provider<T>>,
+        providers: Map<KClass<out T>, () -> T>,
     ): T? {
         // Load the class using the provided ClassLoader and attempt to retrieve the instance.
         val clazz = Class.forName(className, false, classLoader).asSubclass(T::class.java)
@@ -111,6 +110,6 @@ class ComposeAppComponentFactory : AppComponentFactory() {
      * This map is initialized when the application is created via the Metro dependency graph.
      */
     companion object {
-        private lateinit var activityProviders: Map<KClass<out Activity>, Provider<Activity>>
+        private lateinit var activityProviders: Map<KClass<out Activity>, () -> Activity>
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ gson = "2.14.0"
 # https://github.com/pinterest/ktlint
 kotlinter = "5.4.2"
 lifecycleRuntimeKtx = "2.10.0"
-metro = "0.13.2"
+metro = "1.0.0"
 androidxWebkit = "1.16.0"
 
 [libraries]


### PR DESCRIPTION
Upgrades Metro from 0.13.2 to 1.0.0.

### Changes
- Bump `metro` version from `0.13.2` to `1.0.0` in `libs.versions.toml`
- Replace `Provider<T>` with `() -> T` in `AppGraph` and `ComposeAppComponentFactory` — Metro 1.0 uses Kotlin function types instead of the `Provider` wrapper
- Remove `shrinkUnusedBindings` (no longer needed/available in Metro 1.0)
- Move `@Suppress("DelicateApi")` to `enableCircuitCodegen` per updated API

Reference: https://github.com/hossain-khan/android-compose-app-template/pull/387