### PR TITLE
chore: upgrade compose-highlight to 0.13.0 (Maven Central)

### DIFF
--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/comparison/ComparisonScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/comparison/ComparisonScreen.kt
@@ -41,14 +41,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
@@ -60,9 +58,9 @@ import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
-import dev.hossain.highlight.engine.HighlightTheme
-import dev.hossain.highlight.engine.ThemedHighlightResult
 import dev.hossain.highlight.ui.rememberHighlightedCodeBothThemes
+import dev.hossain.highlight.ui.rememberTomorrowNightTheme
+import dev.hossain.highlight.ui.rememberTomorrowTheme
 import dev.hossain.shiki.model.HighlightDualResponse
 import dev.hossain.shiki.model.Theme
 import dev.hossain.syntaxhighlight.R
@@ -524,19 +522,14 @@ private fun ComposeHighlightApproachCard(
     isDark: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val context = LocalContext.current
-    val (lightTheme, darkTheme) =
-        remember(context) {
-            HighlightTheme.tomorrow(context) to HighlightTheme.tomorrowNight(context)
-        }
-    var highlightMs by remember { mutableLongStateOf(0L) }
+    val lightTheme = rememberTomorrowTheme()
+    val darkTheme = rememberTomorrowNightTheme()
 
     val themedResult by rememberHighlightedCodeBothThemes(
         code = sample.code,
         language = sample.toHighlightJsLanguage(),
         lightTheme = lightTheme,
         darkTheme = darkTheme,
-        onHighlightComplete = { durationMs -> highlightMs = durationMs },
     )
 
     val annotatedCode = if (isDark) themedResult?.dark else themedResult?.light
@@ -550,7 +543,7 @@ private fun ComposeHighlightApproachCard(
             } else {
                 CodePreview(annotated = annotatedCode, bgColor = bgColor)
                 Spacer(modifier = Modifier.height(10.dp))
-                ComposeHighlightInfoCard(highlightMs = highlightMs)
+                ComposeHighlightInfoCard(highlightMs = themedResult?.durationMs ?: 0L)
             }
         }
     }

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/composehighlight/ComposeHighlightScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/composehighlight/ComposeHighlightScreen.kt
@@ -45,7 +45,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboard
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
@@ -58,8 +57,11 @@ import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
-import dev.hossain.highlight.engine.HighlightTheme
+import dev.hossain.highlight.ui.rememberAtomOneDarkTheme
+import dev.hossain.highlight.ui.rememberAtomOneLightTheme
 import dev.hossain.highlight.ui.rememberHighlightedCodeBothThemes
+import dev.hossain.highlight.ui.rememberTomorrowNightTheme
+import dev.hossain.highlight.ui.rememberTomorrowTheme
 import dev.hossain.syntaxhighlight.R
 import dev.hossain.syntaxhighlight.data.samples.CodeSample
 import dev.hossain.syntaxhighlight.data.samples.CodeSamples
@@ -234,23 +236,17 @@ private fun ReadyContent(
     state: ComposeHighlightScreen.State.Ready,
     innerPadding: PaddingValues,
 ) {
-    val context = LocalContext.current
+    val tomorrowLight = rememberTomorrowTheme()
+    val tomorrowNight = rememberTomorrowNightTheme()
+    val atomOneLight = rememberAtomOneLightTheme()
+    val atomOneDark = rememberAtomOneDarkTheme()
 
     val (lightTheme, darkTheme) =
-        remember(state.selectedThemePair) {
-            when (state.selectedThemePair) {
-                ComposeHighlightThemePair.TOMORROW -> {
-                    HighlightTheme.tomorrow(context) to HighlightTheme.tomorrowNight(context)
-                }
-
-                ComposeHighlightThemePair.ATOM_ONE -> {
-                    HighlightTheme.atomOneLight(context) to HighlightTheme.atomOneDark(context)
-                }
-            }
+        when (state.selectedThemePair) {
+            ComposeHighlightThemePair.TOMORROW -> tomorrowLight to tomorrowNight
+            ComposeHighlightThemePair.ATOM_ONE -> atomOneLight to atomOneDark
         }
     val hlLanguage = state.selectedSample.toHighlightJsLanguage()
-
-    var highlightMs by remember { mutableStateOf<Long?>(null) }
 
     // Single JS call produces both light + dark AnnotatedStrings; theme switching is instant.
     val themedResult by rememberHighlightedCodeBothThemes(
@@ -258,7 +254,6 @@ private fun ReadyContent(
         language = hlLanguage,
         lightTheme = lightTheme,
         darkTheme = darkTheme,
-        onHighlightComplete = { durationMs -> highlightMs = durationMs },
     )
 
     val annotatedCode = if (state.isDark) themedResult?.dark else themedResult?.light
@@ -330,7 +325,7 @@ private fun ReadyContent(
 
         HorizontalDivider()
         ComposeHighlightMetricsRow(
-            highlightMs = highlightMs,
+            highlightMs = themedResult?.durationMs,
             code = state.selectedSample.code,
             modifier =
                 Modifier

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -101,7 +101,7 @@ shiki-sdk = { group = "com.github.hossain-khan.shiki-token-service", name = "sdk
 
 # compose-highlight - on-device syntax highlighting via Highlight.js WebView
 # https://github.com/hossain-khan/android-compose-highlight
-compose-highlight = { group = "com.github.hossain-khan", name = "android-compose-highlight", version = "0.9.0" }
+compose-highlight = { group = "dev.hossain", name = "compose-highlight", version = "0.13.0" }
 
 # kotlin-textmate transitive dependencies (required by core.jar local library)
 # https://github.com/ivan-magda/kotlin-textmate


### PR DESCRIPTION
## Summary

Upgrades the [compose-highlight](https://github.com/hossain-khan/android-compose-highlight) library from **0.9.0 (JitPack)** to **0.13.0 (Maven Central)**.

## Dependency change

```
// Before (JitPack)
com.github.hossain-khan:android-compose-highlight:0.9.0

// After (Maven Central)
dev.hossain:compose-highlight:0.13.0
```

> **Note:** JitPack is retained in `settings.gradle.kts` because `shiki-token-service` SDK has not yet migrated to Maven Central.

## API migrations (v0.9.0 → v0.13.0)

### Theme helpers (v0.11.0)
Replaced context-based `HighlightTheme` factory calls with new `@Composable` helpers that resolve `LocalContext` internally:

| Before | After |
|---|---|
| `HighlightTheme.tomorrow(context)` | `rememberTomorrowTheme()` |
| `HighlightTheme.tomorrowNight(context)` | `rememberTomorrowNightTheme()` |
| `HighlightTheme.atomOneLight(context)` | `rememberAtomOneLightTheme()` |
| `HighlightTheme.atomOneDark(context)` | `rememberAtomOneDarkTheme()` |

### `onHighlightComplete` removed from `rememberHighlightedCodeBothThemes` (v0.11.0)
Timing is now read directly from `ThemedHighlightResult.durationMs` instead of a callback.

## Files changed
- `gradle/libs.versions.toml` — updated coordinates and version
- `ComposeHighlightScreen.kt` — theme + timing API migration
- `ComparisonScreen.kt` — theme + timing API migration