### PR TITLE
chore: update compose-highlight from 0.13.0 to 0.14.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -101,7 +101,7 @@ shiki-sdk = { group = "com.github.hossain-khan.shiki-token-service", name = "sdk
 
 # compose-highlight - on-device syntax highlighting via Highlight.js WebView
 # https://github.com/hossain-khan/android-compose-highlight
-compose-highlight = { group = "dev.hossain", name = "compose-highlight", version = "0.13.0" }
+compose-highlight = { group = "dev.hossain", name = "compose-highlight", version = "0.14.0" }
 
 # kotlin-textmate transitive dependencies (required by core.jar local library)
 # https://github.com/ivan-magda/kotlin-textmate


### PR DESCRIPTION
## Summary

Updates `compose-highlight` library from `0.13.0` → `0.14.0` (stability and cleanup release).

## Release Notes

### Changed
- **`SelectionContainer` moved inside `AnimatedContent`** — internal restructure, no API change
- **`CodeBlockStyle` annotated `@Stable`** — additive, no code changes needed

### Fixed
- **`WebViewManager` race condition** — `destroy()` no longer hangs the engine permanently
- **U+2028/U+2029 Unicode escaping** — fixes `SyntaxError` on pre-Android 10 WebViews
- **Android Studio `@Preview` support** — composables no longer crash in Preview mode
- **`WebViewManager.webView` memory visibility** — marked `@Volatile` for ARM weak memory model
- **JS-injection defense** — `language` parameter now escapes backslashes and quotes
- **Accessibility improvements** — copy button `contentDescription` + stable `testTag`
- **`HighlightThemeProvider` allocation fix** — avoids new theme instances on recomposition

## Migration

No migration required. This is a drop-in replacement — no API removals or breaking changes.

Full changelog: https://github.com/hossain-khan/android-compose-highlight/compare/0.13.0...0.14.0