### PR TITLE
fix: stabilize eventSink lambdas and hoist approaches list to prevent unnecessary recompositions

### DIFF
--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/comparison/ComparisonScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/comparison/ComparisonScreen.kt
@@ -271,14 +271,19 @@ class ComparisonPresenter
                 }
             }
 
-            val eventSink: (ComparisonScreen.Event) -> Unit = { event ->
-                when (event) {
-                    ComparisonScreen.Event.NavigateBack -> navigator.pop()
-                    is ComparisonScreen.Event.SampleSelected -> selectedSample = event.sample
-                    ComparisonScreen.Event.RetryShiki -> shikiRetry++
-                    ComparisonScreen.Event.RetryTextMate -> textMateRetry++
+            // Remembered so its identity is stable across recompositions; prevents false
+            // inequality in ComparisonScreen.State that includes eventSink.
+            val eventSink: (ComparisonScreen.Event) -> Unit =
+                remember {
+                    { event ->
+                        when (event) {
+                            ComparisonScreen.Event.NavigateBack -> navigator.pop()
+                            is ComparisonScreen.Event.SampleSelected -> selectedSample = event.sample
+                            ComparisonScreen.Event.RetryShiki -> shikiRetry++
+                            ComparisonScreen.Event.RetryTextMate -> textMateRetry++
+                        }
+                    }
                 }
-            }
 
             return ComparisonScreen.State(
                 availableSamples = comparisonSamples,

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/composehighlight/ComposeHighlightScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/composehighlight/ComposeHighlightScreen.kt
@@ -138,19 +138,26 @@ class ComposeHighlightPresenter
             var selectedThemePair by rememberRetained { mutableStateOf(ComposeHighlightThemePair.TOMORROW) }
             var isDark by rememberRetained { mutableStateOf(systemDark) }
 
+            // Remembered so its identity is stable across recompositions; prevents false
+            // inequality in State.Ready that includes eventSink.
+            val eventSink: (ComposeHighlightScreen.Event) -> Unit =
+                remember {
+                    { event ->
+                        when (event) {
+                            ComposeHighlightScreen.Event.NavigateBack -> navigator.pop()
+                            is ComposeHighlightScreen.Event.SampleSelected -> selectedSample = event.sample
+                            is ComposeHighlightScreen.Event.ThemePairSelected -> selectedThemePair = event.pair
+                            ComposeHighlightScreen.Event.ToggleTheme -> isDark = !isDark
+                        }
+                    }
+                }
+
             return ComposeHighlightScreen.State.Ready(
                 samples = CodeSamples.all,
                 selectedSample = selectedSample,
                 selectedThemePair = selectedThemePair,
                 isDark = isDark,
-                eventSink = { event ->
-                    when (event) {
-                        ComposeHighlightScreen.Event.NavigateBack -> navigator.pop()
-                        is ComposeHighlightScreen.Event.SampleSelected -> selectedSample = event.sample
-                        is ComposeHighlightScreen.Event.ThemePairSelected -> selectedThemePair = event.pair
-                        ComposeHighlightScreen.Event.ToggleTheme -> isDark = !isDark
-                    }
-                },
+                eventSink = eventSink,
             )
         }
 

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/home/HomeScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/home/HomeScreen.kt
@@ -104,6 +104,45 @@ private data class HighlightApproach(
     val event: HomeScreen.Event,
 )
 
+// Constant list — hoisted out of the composable to avoid allocation on every recomposition.
+private val approaches =
+    listOf(
+        HighlightApproach(
+            title = "Shiki Server",
+            subtitle =
+                "Server-driven tokenization via Shiki Token Service. " +
+                    "Code is sent to the backend which returns colored tokens; " +
+                    "the app builds an AnnotatedString and renders it natively.",
+            iconRes = R.drawable.cloud_24dp,
+            event = HomeScreen.Event.OpenShikiHighlight,
+        ),
+        HighlightApproach(
+            title = "Kotlin TextMate",
+            subtitle =
+                "On-device tokenization using TextMate grammars and VS Code themes. " +
+                    "No network required — grammars and themes are bundled in the app assets.",
+            iconRes = R.drawable.cloud_off_24dp,
+            event = HomeScreen.Event.OpenTextMateHighlight,
+        ),
+        HighlightApproach(
+            title = "Compose Highlight",
+            subtitle =
+                "On-device highlighting via Highlight.js running in a hidden WebView. " +
+                    "190+ languages with no grammar files to maintain — just drop in the library.",
+            iconRes = R.drawable.cloud_off_24dp,
+            event = HomeScreen.Event.OpenComposeHighlight,
+        ),
+        HighlightApproach(
+            title = "Compare All Highlights",
+            subtitle =
+                "Side-by-side comparison of all three approaches: Shiki (cloud), " +
+                    "TextMate (on-device), and Compose Highlight (WebView). " +
+                    "Includes performance metrics and device footprint analysis for each.",
+            iconRes = R.drawable.code_blocks_24dp,
+            event = HomeScreen.Event.OpenComparison,
+        ),
+    )
+
 @CircuitInject(screen = HomeScreen::class, scope = AppScope::class)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -111,44 +150,6 @@ fun Home(
     state: HomeScreen.State,
     modifier: Modifier = Modifier,
 ) {
-    val approaches =
-        listOf(
-            HighlightApproach(
-                title = "Shiki Server",
-                subtitle =
-                    "Server-driven tokenization via Shiki Token Service. " +
-                        "Code is sent to the backend which returns colored tokens; " +
-                        "the app builds an AnnotatedString and renders it natively.",
-                iconRes = R.drawable.cloud_24dp,
-                event = HomeScreen.Event.OpenShikiHighlight,
-            ),
-            HighlightApproach(
-                title = "Kotlin TextMate",
-                subtitle =
-                    "On-device tokenization using TextMate grammars and VS Code themes. " +
-                        "No network required — grammars and themes are bundled in the app assets.",
-                iconRes = R.drawable.cloud_off_24dp,
-                event = HomeScreen.Event.OpenTextMateHighlight,
-            ),
-            HighlightApproach(
-                title = "Compose Highlight",
-                subtitle =
-                    "On-device highlighting via Highlight.js running in a hidden WebView. " +
-                        "190+ languages with no grammar files to maintain — just drop in the library.",
-                iconRes = R.drawable.cloud_off_24dp,
-                event = HomeScreen.Event.OpenComposeHighlight,
-            ),
-            HighlightApproach(
-                title = "Compare All Highlights",
-                subtitle =
-                    "Side-by-side comparison of all three approaches: Shiki (cloud), " +
-                        "TextMate (on-device), and Compose Highlight (WebView). " +
-                        "Includes performance metrics and device footprint analysis for each.",
-                iconRes = R.drawable.code_blocks_24dp,
-                event = HomeScreen.Event.OpenComparison,
-            ),
-        )
-
     Scaffold(
         modifier = modifier,
         topBar = {

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/shiki/ShikiHighlightScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/shiki/ShikiHighlightScreen.kt
@@ -197,25 +197,19 @@ class ShikiHighlightPresenter
                     }.onFailure { errorMessage = it.message ?: "Unknown error" }
             }
 
-            val eventSink: (ShikiHighlightScreen.Event) -> Unit = { event ->
-                when (event) {
-                    ShikiHighlightScreen.Event.NavigateBack -> {
-                        navigator.pop()
-                    }
-
-                    is ShikiHighlightScreen.Event.SampleSelected -> {
-                        selectedSample = event.sample
-                    }
-
-                    is ShikiHighlightScreen.Event.ThemePairSelected -> {
-                        selectedThemePair = event.themePair
-                    }
-
-                    ShikiHighlightScreen.Event.Retry -> {
-                        retryTrigger++
+            // Remembered so its identity is stable across recompositions; prevents false
+            // inequality in the State data classes that include eventSink.
+            val eventSink: (ShikiHighlightScreen.Event) -> Unit =
+                remember {
+                    { event ->
+                        when (event) {
+                            ShikiHighlightScreen.Event.NavigateBack -> navigator.pop()
+                            is ShikiHighlightScreen.Event.SampleSelected -> selectedSample = event.sample
+                            is ShikiHighlightScreen.Event.ThemePairSelected -> selectedThemePair = event.themePair
+                            ShikiHighlightScreen.Event.Retry -> retryTrigger++
+                        }
                     }
                 }
-            }
 
             val common =
                 Triple(

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/textmate/TextMateHighlightScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/textmate/TextMateHighlightScreen.kt
@@ -182,14 +182,19 @@ class TextMateHighlightPresenter
                 }
             }
 
-            val eventSink: (TextMateHighlightScreen.Event) -> Unit = { event ->
-                when (event) {
-                    TextMateHighlightScreen.Event.NavigateBack -> navigator.pop()
-                    is TextMateHighlightScreen.Event.SampleSelected -> selectedSample = event.sample
-                    TextMateHighlightScreen.Event.ToggleTheme -> isDark = !isDark
-                    is TextMateHighlightScreen.Event.ThemePairSelected -> selectedThemePair = event.pair
+            // Remembered so its identity is stable across recompositions; prevents false
+            // inequality in the State data classes that include eventSink.
+            val eventSink: (TextMateHighlightScreen.Event) -> Unit =
+                remember {
+                    { event ->
+                        when (event) {
+                            TextMateHighlightScreen.Event.NavigateBack -> navigator.pop()
+                            is TextMateHighlightScreen.Event.SampleSelected -> selectedSample = event.sample
+                            TextMateHighlightScreen.Event.ToggleTheme -> isDark = !isDark
+                            is TextMateHighlightScreen.Event.ThemePairSelected -> selectedThemePair = event.pair
+                        }
+                    }
                 }
-            }
 
             return when {
                 errorMessage != null -> {


### PR DESCRIPTION
## Credits 🙏🏽 
https://github.com/chrisbanes/skills


## Summary

Fixes two Compose recomposition performance issues identified via stability diagnostics.

## Problems

### 1. Unstable `eventSink` lambda in all four presenters
`ShikiHighlightPresenter`, `TextMateHighlightPresenter`, `ComparisonPresenter`, `ComposeHighlightPresenter` all created a bare `(Event) -> Unit` lambda on every `present()` call. Non-composable lambdas are **not** auto-remembered by the Compose compiler even with Kotlin 2.0.20+ strong skipping.

Because `eventSink` is a property of every `State` data class, `equals()` always returned `false` between compositions — even when the sample, theme, and loading state were all unchanged. This caused the UI composable to recompose unconditionally on every presenter pass.

### 2. `approaches` list recreated on every recomposition in `HomeScreen`
`val approaches = listOf(...)` inside `Home()` allocated four new `HighlightApproach` objects every composition. The list is constant data that never changes.

## Fixes

- Wrapped each `eventSink` in `remember { }`. All captures are stable: the `MutableState` objects backing the `by`-delegated vars (the delegate object, not its value) and the constructor-injected `navigator`.
- Hoisted `approaches` to a top-level `private val` in `HomeScreen.kt`.

## Not included

Blocking `CodeHighlighter.highlight()` call on the main thread inside `remember` in `TextMateHighlightScreen` and `ComparisonScreen` — tracked separately as it requires moving tokenization into the presenter layer.