### PR TITLE
feat: add app info bottom sheet overlay

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "dev.hossain.syntaxhighlight"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 3
-        versionName = "1.2.0"
+        versionCode = 4
+        versionName = "1.3.0"
 
         // Read key or other properties from local.properties
         val localProperties =

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/home/HomeScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/home/HomeScreen.kt
@@ -198,7 +198,7 @@ fun Home(
                 actions = {
                     IconButton(onClick = { state.eventSink(HomeScreen.Event.ShowAppInfo) }) {
                         Icon(
-                            painter = painterResource(R.drawable.baseline_info_24),
+                            painter = painterResource(R.drawable.info_24dp),
                             contentDescription = "App info",
                         )
                     }

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/home/HomeScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/home/HomeScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -22,25 +23,31 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.overlay.LocalOverlayHost
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
+import com.slack.circuitx.overlays.BottomSheetOverlay
 import dev.hossain.syntaxhighlight.R
 import dev.hossain.syntaxhighlight.circuit.comparison.ComparisonScreen
 import dev.hossain.syntaxhighlight.circuit.composehighlight.ComposeHighlightScreen
+import dev.hossain.syntaxhighlight.circuit.overlay.AppInfoBottomSheet
 import dev.hossain.syntaxhighlight.circuit.shiki.ShikiHighlightScreen
 import dev.hossain.syntaxhighlight.circuit.textmate.TextMateHighlightScreen
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -66,6 +73,8 @@ data object HomeScreen : Screen {
         data object OpenComparison : Event
 
         data object OpenComposeHighlight : Event
+
+        data object ShowAppInfo : Event
     }
 }
 
@@ -79,16 +88,47 @@ class HomePresenter
     constructor(
         @Assisted private val navigator: Navigator,
     ) : Presenter<HomeScreen.State> {
+        @OptIn(ExperimentalMaterial3Api::class)
         @Composable
-        override fun present(): HomeScreen.State =
-            HomeScreen.State { event ->
-                when (event) {
-                    HomeScreen.Event.OpenShikiHighlight -> navigator.goTo(ShikiHighlightScreen)
-                    HomeScreen.Event.OpenTextMateHighlight -> navigator.goTo(TextMateHighlightScreen)
-                    HomeScreen.Event.OpenComparison -> navigator.goTo(ComparisonScreen)
-                    HomeScreen.Event.OpenComposeHighlight -> navigator.goTo(ComposeHighlightScreen)
+        override fun present(): HomeScreen.State {
+            val overlayHost = LocalOverlayHost.current
+            val scope = rememberCoroutineScope()
+
+            val eventSink: (HomeScreen.Event) -> Unit =
+                remember {
+                    { event ->
+                        when (event) {
+                            HomeScreen.Event.OpenShikiHighlight -> {
+                                navigator.goTo(ShikiHighlightScreen)
+                            }
+
+                            HomeScreen.Event.OpenTextMateHighlight -> {
+                                navigator.goTo(TextMateHighlightScreen)
+                            }
+
+                            HomeScreen.Event.OpenComparison -> {
+                                navigator.goTo(ComparisonScreen)
+                            }
+
+                            HomeScreen.Event.OpenComposeHighlight -> {
+                                navigator.goTo(ComposeHighlightScreen)
+                            }
+
+                            HomeScreen.Event.ShowAppInfo -> {
+                                scope.launch {
+                                    overlayHost.show(
+                                        BottomSheetOverlay(model = Unit, onDismiss = { Unit }) { _, _ ->
+                                            AppInfoBottomSheet()
+                                        },
+                                    )
+                                }
+                            }
+                        }
+                    }
                 }
-            }
+
+            return HomeScreen.State(eventSink = eventSink)
+        }
 
         @CircuitInject(HomeScreen::class, AppScope::class)
         @AssistedFactory
@@ -153,7 +193,17 @@ fun Home(
     Scaffold(
         modifier = modifier,
         topBar = {
-            TopAppBar(title = { Text("Syntax Highlight") })
+            TopAppBar(
+                title = { Text("Syntax Highlight") },
+                actions = {
+                    IconButton(onClick = { state.eventSink(HomeScreen.Event.ShowAppInfo) }) {
+                        Icon(
+                            painter = painterResource(R.drawable.baseline_info_24),
+                            contentDescription = "App info",
+                        )
+                    }
+                },
+            )
         },
     ) { innerPadding ->
         LazyColumn(

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/overlay/AppInfoOverlay.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/overlay/AppInfoOverlay.kt
@@ -1,0 +1,130 @@
+package dev.hossain.syntaxhighlight.circuit.overlay
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import dev.hossain.syntaxhighlight.R
+
+private data class AppLink(
+    val label: String,
+    val url: String,
+)
+
+private val appLinks =
+    listOf(
+        AppLink(
+            label = "GitHub Repository",
+            url = "https://github.com/hossain-khan/android-syntax-highlighter-compose",
+        ),
+        AppLink(
+            label = "Blog: Shiki — Server-Driven Syntax Highlighting on Android",
+            url = "https://hossain.dev/posts/syntax-highlighting-on-android-bringing-shiki-engine-to-compose/",
+        ),
+        AppLink(
+            label = "Blog: Highlight.js — Native Compose Engine on Android",
+            url = "https://hossain.dev/posts/syntax-highlighting-on-android-highlight-js-native-compose-engine/",
+        ),
+    )
+
+/**
+ * Bottom sheet content for the app-info overlay.
+ *
+ * Displays the app name, version, a short description of what the app does,
+ * and a set of external links (GitHub repository and blog posts).
+ *
+ * Intended to be used as the [com.slack.circuitx.overlays.BottomSheetOverlay] body,
+ * triggered from the [dev.hossain.syntaxhighlight.circuit.home.HomeScreen] toolbar.
+ */
+@Composable
+fun AppInfoBottomSheet(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
+    val versionName =
+        remember {
+            @Suppress("DEPRECATION")
+            context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: "—"
+        }
+
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(bottom = 24.dp),
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .padding(horizontal = 24.dp)
+                    .padding(top = 8.dp, bottom = 16.dp),
+        ) {
+            Text(
+                text = "Syntax Highlighter",
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = "v$versionName",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 2.dp),
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text =
+                    "A showcase of syntax highlighting approaches in Jetpack Compose: " +
+                        "server-driven tokenization via Shiki, on-device TextMate grammar " +
+                        "rendering, and WebView-based Highlight.js.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+
+        HorizontalDivider()
+
+        Text(
+            text = "Links",
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary,
+            modifier =
+                Modifier
+                    .padding(horizontal = 24.dp)
+                    .padding(top = 16.dp, bottom = 4.dp),
+        )
+
+        appLinks.forEach { link ->
+            ListItem(
+                headlineContent = {
+                    Text(
+                        text = link.label,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                },
+                trailingContent = {
+                    Icon(
+                        painter = painterResource(R.drawable.open_in_new_24dp),
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                },
+                modifier = Modifier.clickable { uriHandler.openUri(link.url) },
+            )
+        }
+    }
+}

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/overlay/AppInfoOverlay.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/overlay/AppInfoOverlay.kt
@@ -24,6 +24,7 @@ import dev.hossain.syntaxhighlight.R
 private data class AppLink(
     val label: String,
     val url: String,
+    val iconRes: Int,
 )
 
 private val appLinks =
@@ -31,14 +32,17 @@ private val appLinks =
         AppLink(
             label = "GitHub Repository",
             url = "https://github.com/hossain-khan/android-syntax-highlighter-compose",
+            iconRes = R.drawable.github_logo,
         ),
         AppLink(
             label = "Blog: Shiki — Server-Driven Syntax Highlighting on Android",
             url = "https://hossain.dev/posts/syntax-highlighting-on-android-bringing-shiki-engine-to-compose/",
+            iconRes = R.drawable.open_in_new_24dp,
         ),
         AppLink(
             label = "Blog: Highlight.js — Native Compose Engine on Android",
             url = "https://hossain.dev/posts/syntax-highlighting-on-android-highlight-js-native-compose-engine/",
+            iconRes = R.drawable.open_in_new_24dp,
         ),
     )
 
@@ -117,7 +121,7 @@ fun AppInfoBottomSheet(modifier: Modifier = Modifier) {
                 },
                 trailingContent = {
                     Icon(
-                        painter = painterResource(R.drawable.open_in_new_24dp),
+                        painter = painterResource(link.iconRes),
                         contentDescription = null,
                         modifier = Modifier.size(18.dp),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/overlay/AppInfoOverlay.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/overlay/AppInfoOverlay.kt
@@ -35,12 +35,12 @@ private val appLinks =
             iconRes = R.drawable.github_logo,
         ),
         AppLink(
-            label = "Blog: Shiki — Server-Driven Syntax Highlighting on Android",
+            label = "Blog: Shiki - Server-Driven Syntax Highlighting on Android",
             url = "https://hossain.dev/posts/syntax-highlighting-on-android-bringing-shiki-engine-to-compose/",
             iconRes = R.drawable.open_in_new_24dp,
         ),
         AppLink(
-            label = "Blog: Highlight.js — Native Compose Engine on Android",
+            label = "Blog: Highlight.js - Native Compose Engine on Android",
             url = "https://hossain.dev/posts/syntax-highlighting-on-android-highlight-js-native-compose-engine/",
             iconRes = R.drawable.open_in_new_24dp,
         ),

--- a/app/src/main/res/drawable/github_logo.xml
+++ b/app/src/main/res/drawable/github_logo.xml
@@ -1,0 +1,20 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="48dp" android:viewportHeight="20" android:viewportWidth="20" android:width="48dp">
+      
+    <path android:fillColor="#FF000000" android:fillType="evenOdd" android:pathData="m10,0c5.523,0 10,4.59 10,10.253 0,4.529 -2.862,8.371 -6.833,9.728 -0.507,0.101 -0.687,-0.219 -0.687,-0.492 0,-0.338 0.012,-1.442 0.012,-2.814 0,-0.956 -0.32,-1.58 -0.679,-1.898 2.227,-0.254 4.567,-1.121 4.567,-5.059 0,-1.12 -0.388,-2.034 -1.03,-2.752 0.104,-0.259 0.447,-1.302 -0.098,-2.714 0,0 -0.838,-0.275 -2.747,1.051 -0.799,-0.227 -1.655,-0.341 -2.505,-0.345 -0.85,0.004 -1.705,0.118 -2.503,0.345 -1.911,-1.326 -2.751,-1.051 -2.751,-1.051 -0.543,1.412 -0.2,2.455 -0.097,2.714 -0.639,0.718 -1.03,1.632 -1.03,2.752 0,3.928 2.335,4.808 4.556,5.067 -0.286,0.256 -0.545,0.708 -0.635,1.371 -0.57,0.262 -2.018,0.715 -2.91,-0.852 0,0 -0.529,-0.985 -1.533,-1.057 0,0 -0.975,-0.013 -0.068,0.623 0,0 0.655,0.315 1.11,1.5 0,0 0.587,1.83 3.369,1.21 0.005,0.857 0.014,1.665 0.014,1.909 0,0.271 -0.184,0.588 -0.683,0.493 -3.974,-1.355 -6.839,-5.199 -6.839,-9.729 0,-5.663 4.478,-10.253 10,-10.253"/>
+    
+</vector>

--- a/app/src/main/res/drawable/info_24dp.xml
+++ b/app/src/main/res/drawable/info_24dp.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M440,680h80v-240h-80v240ZM508.5,348.5Q520,337 520,320t-11.5,-28.5Q497,280 480,280t-28.5,11.5Q440,303 440,320t11.5,28.5Q463,360 480,360t28.5,-11.5ZM480,880q-83,0 -156,-31.5T197,763q-54,-54 -85.5,-127T80,480q0,-83 31.5,-156T197,197q54,-54 127,-85.5T480,80q83,0 156,31.5T763,197q54,54 85.5,127T880,480q0,83 -31.5,156T763,763q-54,54 -127,85.5T480,880ZM480,800q134,0 227,-93t93,-227q0,-134 -93,-227t-227,-93q-134,0 -227,93t-93,227q0,134 93,227t227,93ZM480,480Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/app/src/main/res/drawable/open_in_new_24dp.xml
+++ b/app/src/main/res/drawable/open_in_new_24dp.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="m200,840q-33,0 -56.5,-23.5t-23.5,-56.5v-560q0,-33 23.5,-56.5t56.5,-23.5h280v80h-280v560h560v-280h80v280q0,33 -23.5,56.5t-56.5,23.5zM388,628 L332,572 704,200h-144v-80h280v280h-80v-144z"
+      android:fillColor="#e3e3e3"/>
+</vector>


### PR DESCRIPTION
## Summary

Adds an **info (ℹ) icon** to the Home screen toolbar that opens a Circuit `BottomSheetOverlay` with app metadata and links.

## What's shown in the sheet

- **App name** + **version** (read from `PackageInfo` at runtime)
- Short description of the three highlighting approaches
- Clickable external links:
  - 🔗 GitHub Repository
  - 📝 Blog: Shiki — Server-Driven Syntax Highlighting on Android
  - 📝 Blog: Highlight.js — Native Compose Engine on Android

## Implementation details

- `AppInfoOverlay.kt` — standalone `@Composable` for the sheet body; uses `LocalUriHandler` to open links, `ListItem` rows with trailing open-in-new icon
- `open_in_new_24dp.xml` — Material vector drawable for external link affordance
- `HomeScreen` — new `ShowAppInfo` event; presenter updated to use `LocalOverlayHost` + `rememberCoroutineScope`; `eventSink` wrapped in `remember {}` for stability

Closes #N/A