### PR TITLE
chore: bump compose-highlight from 0.16.0 to 0.17.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ metro = "1.0.0"
 androidxWebkit = "1.16.0"
 
 # https://github.com/hossain-khan/android-compose-highlight
-composeHighlight = "0.16.0"
+composeHighlight = "0.17.2"
 
 # https://github.com/ivan-magda/kotlin-textmate
 kotlinTextmate = "0.1.0"


### PR DESCRIPTION
## Summary

Bumps [compose-highlight](https://github.com/hossain-khan/android-compose-highlight) from `0.16.0` to `0.17.2`.

### Changes

- **0.17.0**: Fix `ThemeParser` incorrectly applying pseudo-selector (e.g. `::selection`) background as theme background color
- **0.17.1**: Fix `ThemeParser` descendant selectors (e.g. `.hljs mark`) leaking into base `.hljs` styles (affected agate background color)
- **0.17.2**: Fix `ThemeParser` multiple CSS rules for the same selector being overwritten instead of merged (affected nord background color)

No API changes - safe drop-in upgrade from `0.16.0`.