### PR TITLE
chore: bump compose-highlight from 0.17.2 to 0.18.0

### DIFF
--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/comparison/ComparisonScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/comparison/ComparisonScreen.kt
@@ -59,6 +59,7 @@ import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
+import dev.hossain.highlight.engine.HighlightTimings
 import dev.hossain.highlight.ui.rememberHighlightedCodeBothThemes
 import dev.hossain.highlight.ui.rememberTomorrowNightTheme
 import dev.hossain.highlight.ui.rememberTomorrowTheme
@@ -80,6 +81,7 @@ import dev.zacsweers.metro.AssistedInject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
+import kotlin.time.Duration
 import kotlin.time.measureTimedValue
 
 /**
@@ -577,7 +579,7 @@ private fun ComposeHighlightApproachCard(
             } else {
                 CodePreview(annotated = annotatedCode, bgColor = bgColor)
                 Spacer(modifier = Modifier.height(10.dp))
-                ComposeHighlightInfoCard(highlightMs = themedResult?.durationMs ?: 0L)
+                ComposeHighlightInfoCard(timings = themedResult?.timings)
             }
         }
     }
@@ -679,13 +681,26 @@ private fun TextMateInfoCard(
 
 @Composable
 private fun ComposeHighlightInfoCard(
-    highlightMs: Long,
+    timings: HighlightTimings?,
     modifier: Modifier = Modifier,
 ) {
     val libKb = COMPOSE_HIGHLIGHT_LIBRARY_BYTES / 1000L
     InfoCard(modifier = modifier) {
         InfoSection(title = "Performance") {
-            InfoRow(label = "⏱  WebView JS round-trip", value = "${highlightMs}ms", emphasized = true)
+            if (timings != null) {
+                InfoRow(label = "🌐  JS bridge", value = timings.jsBridge.toDisplayString())
+                InfoRow(label = "📝  JSON unescape", value = timings.jsonUnescape.toDisplayString())
+                InfoRow(label = "🔍  HTML parse", value = timings.htmlParse.toDisplayString())
+                InfoRow(label = "🌳  Tree walk", value = timings.treeWalk.toDisplayString())
+                if (timings.themeParse > Duration.ZERO) {
+                    InfoRow(label = "🎨  Theme parse", value = timings.themeParse.toDisplayString())
+                } else {
+                    InfoRow(label = "🎨  Theme parse", value = "cached")
+                }
+                InfoRow(label = "⏱  Total", value = timings.total.toDisplayString(), emphasized = true)
+            } else {
+                InfoRow(label = "⏱  Total", value = "…", emphasized = true)
+            }
             InfoSubtitle("Single shared WebView — one initialization cost shared across all blocks.")
         }
         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
@@ -705,6 +720,8 @@ private fun ComposeHighlightInfoCard(
         }
     }
 }
+
+private fun Duration.toDisplayString(): String = if (inWholeMilliseconds < 1) "${inWholeMicroseconds}µs" else "${inWholeMilliseconds}ms"
 
 @Composable
 private fun InfoCard(

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/comparison/ComparisonScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/comparison/ComparisonScreen.kt
@@ -549,8 +549,8 @@ private fun CodeSample.toHighlightJsLanguage(): String =
         else -> label.lowercase()
     }
 
-/** Approximate size of the compose-highlight library (WebView-based, no grammar assets). */
-private const val COMPOSE_HIGHLIGHT_LIBRARY_BYTES = 50_000L
+/** Approximate total app size impact of the compose-highlight library (~308 KB assets + ~235 KB dex). */
+private const val COMPOSE_HIGHLIGHT_LIBRARY_BYTES = 440_000L
 
 @Composable
 private fun ComposeHighlightApproachCard(
@@ -706,11 +706,13 @@ private fun ComposeHighlightInfoCard(
         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
         InfoSection(title = "Device Footprint (approx.)") {
             InfoRow(label = "📄  Grammar files", value = "0 KB")
-            InfoRow(label = "🎨  Theme files", value = "0 KB")
+            InfoRow(label = "🎨  Theme files", value = "~1 KB (per built-in theme)")
             InfoRow(label = "📚  Library (incl. Highlight.js)", value = "~$libKb KB")
             HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
-            InfoRow(label = "📦  Total", value = "~$libKb KB", emphasized = true)
-            InfoSubtitle("190+ languages and themes are bundled inside the library — no assets to manage.")
+            InfoRow(label = "📦  Total", value = "~$libKb KB + themes", emphasized = true)
+            InfoSubtitle(
+                "190+ languages bundled in JS. Each built-in theme adds ~1 KB; custom themes from assets or CSS are user-supplied.",
+            )
         }
         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
         InfoSection(title = "Capabilities") {

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/composehighlight/ComposeHighlightScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/composehighlight/ComposeHighlightScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
@@ -57,6 +58,7 @@ import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
+import dev.hossain.highlight.engine.HighlightTimings
 import dev.hossain.highlight.ui.rememberAtomOneDarkTheme
 import dev.hossain.highlight.ui.rememberAtomOneLightTheme
 import dev.hossain.highlight.ui.rememberHighlightedCodeBothThemes
@@ -71,6 +73,7 @@ import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
+import kotlin.time.Duration
 
 /** Named light/dark [HighlightTheme] pairs available on this screen. */
 enum class ComposeHighlightThemePair(
@@ -332,7 +335,7 @@ private fun ReadyContent(
 
         HorizontalDivider()
         ComposeHighlightMetricsRow(
-            highlightMs = themedResult?.durationMs,
+            timings = themedResult?.timings,
             code = state.selectedSample.code,
             modifier =
                 Modifier
@@ -436,30 +439,67 @@ private fun ThemePairDropdown(
 
 @Composable
 private fun ComposeHighlightMetricsRow(
-    highlightMs: Long?,
+    timings: HighlightTimings?,
     code: String,
     modifier: Modifier = Modifier,
 ) {
     val lines = code.lines().size
     val chars = code.length
-    Row(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        Text(
-            text = if (highlightMs != null) "⏱ ${highlightMs}ms" else "⏱ …",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Text(
-            text = "↕ $lines lines",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Text(
-            text = "∑ $chars chars",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+    Column(modifier = modifier) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = if (timings != null) "⏱ ${timings.total.inWholeMilliseconds}ms total" else "⏱ …",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = "↕ $lines lines",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = "∑ $chars chars",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        if (timings != null) {
+            Row(
+                modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                TimingLabel("JS", timings.jsBridge)
+                TimingLabel("unescape", timings.jsonUnescape)
+                TimingLabel("HTML", timings.htmlParse)
+                TimingLabel("walk", timings.treeWalk)
+                if (timings.themeParse > Duration.ZERO) {
+                    TimingLabel("theme", timings.themeParse)
+                } else {
+                    Text(
+                        text = "theme: cached",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                        modifier = Modifier.wrapContentWidth(),
+                    )
+                }
+            }
+        }
     }
 }
+
+@Composable
+private fun TimingLabel(
+    label: String,
+    duration: Duration,
+) {
+    Text(
+        text = "$label: ${duration.toDisplayString()}",
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.wrapContentWidth(),
+    )
+}
+
+private fun Duration.toDisplayString(): String = if (inWholeMilliseconds < 1) "${inWholeMicroseconds}µs" else "${inWholeMilliseconds}ms"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ metro = "1.0.0"
 androidxWebkit = "1.16.0"
 
 # https://github.com/hossain-khan/android-compose-highlight
-composeHighlight = "0.17.2"
+composeHighlight = "0.18.0"
 
 # https://github.com/ivan-magda/kotlin-textmate
 kotlinTextmate = "0.1.0"


### PR DESCRIPTION
## Summary

Bumps [compose-highlight](https://github.com/hossain-khan/android-compose-highlight) from `0.17.2` to `0.18.0` and surfaces the new timing API in the UI.

### Library update - 0.18.0

Adds `HighlightTimings`, a new data class exposing `Duration` measurements for each stage of the highlight pipeline:

| Stage | Description |
|---|---|
| `jsBridge` | `evaluateJavascript()` round-trip into WebView |
| `jsonUnescape` | Character-by-character JSON string unescape |
| `htmlParse` | `Jsoup.parseBodyFragment()` - HTML to DOM |
| `treeWalk` | DOM node walk + `SpanStyle` lookup from theme map |
| `themeParse` | `ThemeParser.parse()` - first call only; `Duration.ZERO` on cache hits |
| `total` | End-to-end wall-clock time |

### UI changes

**Compose Highlight screen** - metrics row now shows a second line with per-stage durations:
```
⏱ 18ms total   ↕ 42 lines   ∑ 1024 chars
JS: 12ms · unescape: 450µs · HTML: 1ms · walk: 2ms · theme: cached
```

**Comparison screen** - `ComposeHighlightInfoCard` Performance section now lists each timing stage as a labeled row (matching Shiki card style), and the Device Footprint section is corrected:
- Library size: `~50 KB` → `~440 KB` (actual measured APK delta)
- Theme files: `0 KB` → `~1 KB (per built-in theme)`