### PR TITLE
feat: add cold start info banner in ComparisonScreen

### DIFF
--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/comparison/ComparisonScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/comparison/ComparisonScreen.kt
@@ -455,8 +455,8 @@ private fun ColdStartInfoBanner(modifier: Modifier = Modifier) {
             )
             Text(
                 text =
-                    "First load timings may be high due to cold start (WebView warm-up, theme parse). " +
-                        "Switch languages a few times to see warmed-up timings.",
+                    "First load timings may be high due to cold start (WebView warm-up, theme parse, " +
+                        "cloud service spin-up). Switch languages a few times to see warmed-up timings.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSecondaryContainer,
             )

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/comparison/ComparisonScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/comparison/ComparisonScreen.kt
@@ -392,6 +392,8 @@ fun Comparison(
                 onSelect = { state.eventSink(ComparisonScreen.Event.SampleSelected(it)) },
             )
 
+            ColdStartInfoBanner()
+
             ApproachSectionHeader(
                 icon = R.drawable.cloud_24dp,
                 label = "Cloud — Shiki Token Service",
@@ -427,6 +429,37 @@ fun Comparison(
             )
 
             Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun ColdStartInfoBanner(modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            ),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.Top,
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.info_24dp),
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Text(
+                text =
+                    "First load timings may be high due to cold start (WebView warm-up, theme parse). " +
+                        "Switch languages a few times to see warmed-up timings.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a `secondaryContainer` info banner below the language dropdown on the Compare All screen.

The banner explains that first-load timings may be elevated due to cold start (WebView warm-up + first-use theme parse) and prompts users to switch languages a few times to see warmed-up timings - helping avoid confusion when comparing the three approaches.