### PR TITLE
chore: upgrade compose-highlight 0.18.0 → 0.19.0

### DIFF
--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/composehighlight/ComposeHighlightScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/composehighlight/ComposeHighlightScreen.kt
@@ -89,8 +89,42 @@ enum class ComposeHighlightThemePair(
  * which runs [Highlight.js](https://highlightjs.org/) inside a hidden WebView and converts
  * the tokenised HTML output to a native Compose [AnnotatedString].
  *
- * No network calls are made; all highlighting happens on-device via a single [dev.hossain.highlight.engine.HighlightEngine]
- * instance. Timing reflects the full WebView JS round-trip.
+ * No network calls are made; all highlighting happens on-device via a single
+ * [dev.hossain.highlight.engine.HighlightEngine] instance. Timing reflects the full WebView
+ * JS round-trip.
+ *
+ * ## Available compose-highlight APIs
+ *
+ * The library ships four levels of API for rendering highlighted code:
+ *
+ * - **`SyntaxHighlightedCode`** — highest-level drop-in composable. Handles background,
+ *   horizontal scroll, padding, line numbers, copy button, language label, and
+ *   [androidx.compose.foundation.text.selection.SelectionContainer] automatically. Best for
+ *   static single-theme displays.
+ * - **[dev.hossain.highlight.ui.rememberHighlightedCode]** — returns
+ *   `State<AnnotatedString?>`. Re-runs automatically when `code`, `language`, or `theme`
+ *   changes. Use when you need full control over the `Text` call.
+ * - **[dev.hossain.highlight.ui.rememberHighlightedCodeBothThemes]** — fires a single JS call
+ *   and returns both light **and** dark [androidx.compose.ui.text.AnnotatedString]s. Theme
+ *   switching after the initial highlight is instant with no re-highlighting.
+ * - **[dev.hossain.highlight.engine.HighlightEngine]** — headless engine. Use `highlight()` or
+ *   `highlightBothThemes()` directly for programmatic highlighting outside of composition.
+ *
+ * ## Why this screen uses [dev.hossain.highlight.ui.rememberHighlightedCodeBothThemes]
+ *
+ * This screen has requirements that go beyond what `SyntaxHighlightedCode` covers:
+ *
+ * 1. **Instant dual-theme toggling** — a single JS call produces both light and dark
+ *    [androidx.compose.ui.text.AnnotatedString]s. The dark/light toggle in the top bar is a
+ *    free state read with zero re-highlighting. `SyntaxHighlightedCode` renders one theme at a
+ *    time and would re-highlight on every toggle.
+ * 2. **Per-stage timing metrics** — the screen displays a breakdown of
+ *    [dev.hossain.highlight.engine.HighlightTimings] fields (`jsBridge`, `jsonUnescape`,
+ *    `htmlParse`, `treeWalk`, `themeParse`, `total`) sourced from `themedResult?.timings`.
+ *    `SyntaxHighlightedCode` does not expose internal timing data to callers.
+ * 3. **Custom layout control** — the screen combines language + theme dropdowns, a scrollable
+ *    code block, and the metrics row in a single `Column`. Writing the `Text` directly avoids
+ *    suppressing `SyntaxHighlightedCode`'s own copy button and language label.
  */
 @Parcelize
 data object ComposeHighlightScreen : Screen {
@@ -258,7 +292,14 @@ private fun ReadyContent(
         }
     val hlLanguage = state.selectedSample.toHighlightJsLanguage()
 
-    // Single JS call produces both light + dark AnnotatedStrings; theme switching is instant.
+    // [rememberHighlightedCodeBothThemes] is used here instead of the higher-level
+    // SyntaxHighlightedCode composable for three reasons:
+    //  1. A single JS call produces both light and dark AnnotatedStrings so that theme
+    //     toggling is instantaneous — no re-highlighting on each switch.
+    //  2. themedResult.timings exposes per-stage HighlightTimings (jsBridge, htmlParse,
+    //     treeWalk, etc.) for the metrics row; SyntaxHighlightedCode does not surface these.
+    //  3. The screen owns its own layout (dropdowns + code block + metrics row) which
+    //     is simpler to compose than overriding SyntaxHighlightedCode's built-in chrome.
     val themedResult by rememberHighlightedCodeBothThemes(
         code = state.selectedSample.code,
         language = hlLanguage,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ metro = "1.0.0"
 androidxWebkit = "1.16.0"
 
 # https://github.com/hossain-khan/android-compose-highlight
-composeHighlight = "0.18.0"
+composeHighlight = "0.19.0"
 
 # https://github.com/ivan-magda/kotlin-textmate
 kotlinTextmate = "0.1.0"


### PR DESCRIPTION
## Summary

Bumps `compose-highlight` from `0.18.0` to `0.19.0`.

## What changed in 0.19.0

### Breaking (not applicable to this app)

`SyntaxHighlightedCode` received a **slot API hardening** — boolean visibility flags and partial slot parameters were replaced with full composable slots:

| Removed | Replacement |
|---|---|
| `showLanguageLabel: Boolean` | `languageLabelContent: (@Composable () -> Unit)?` |
| `showCopyButton: Boolean` | `copyButtonContent: (@Composable (onClick: () -> Unit) -> Unit)?` |
| `copyButtonIcon: (@Composable (tint: Color) -> Unit)?` | (merged into `copyButtonContent`) |
| `copyButtonContentDescription: String` | (merged into `copyButtonContent`) |

`null` = hide, non-null = show (custom or default). `Surface` now explicitly sets `contentColor = textColor` so `LocalContentColor.current` resolves correctly inside both slots.

### New public helpers

- **`SyntaxHighlightedCodeDefaults.CopyButton`** — renders the default `⧉` copy icon inside an `IconButton`; accepts `onClick`, `tint`, `contentDescription`, and `size`.
- **`SyntaxHighlightedCodeDefaults.LanguageLabel`** — renders the language badge; accepts `language`, `color`, and `fontSize`.

## API levels available in compose-highlight

The library ships three levels of API for rendering highlighted code:

| API | Level | Description |
|---|---|---|
| `SyntaxHighlightedCode` | High | Full drop-in composable. Handles background, scroll, padding, line numbers, copy button, language label, and `SelectionContainer` automatically. Best for static single-theme displays. |
| `rememberHighlightedCode` | Mid | Returns `State<AnnotatedString?>`. Re-runs automatically when `code`, `language`, or `theme` changes. Use when you need control over the `Text` call. |
| `rememberHighlightedCodeBothThemes` | Mid | Single JS call produces both light **and** dark `AnnotatedString`s. Theme switching after the initial highlight is instant — no re-highlighting needed. |
| `HighlightEngine` | Low | Headless engine. Use `highlight()` or `highlightBothThemes()` directly for programmatic `AnnotatedString` generation outside of composition. |

## Why this app uses `rememberHighlightedCodeBothThemes` (not `SyntaxHighlightedCode`)

This screen has requirements that go beyond what `SyntaxHighlightedCode` covers:

1. **Instant dual-theme toggling** — `rememberHighlightedCodeBothThemes` fires a single JS call and returns both `light` and `dark` `AnnotatedString`s. The dark/light toggle in the top bar is a free state read with zero re-highlighting. `SyntaxHighlightedCode` only renders one theme at a time and would re-highlight on every toggle.

2. **Per-stage timing metrics row** — the screen displays a breakdown of `HighlightTimings` fields (`jsBridge`, `jsonUnescape`, `htmlParse`, `treeWalk`, `themeParse`, `total`) sourced from `themedResult?.timings`. `SyntaxHighlightedCode` does not expose its internal timing data to the caller.

3. **Custom layout control** — the screen combines language + theme dropdowns, a scrollable code block, and the metrics row in a single `Column`. Wrapping `SyntaxHighlightedCode` inside that layout while suppressing its own copy button and language label would require more configuration than writing the `Text` directly.

## Verification

`./gradlew assembleDebug` — ✅ BUILD SUCCESSFUL