### PR TITLE
[ADDED] Experimental benchmark module

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,75 @@
+# Benchmarks
+
+This project includes an [AndroidX Microbenchmark](https://developer.android.com/jetpack/androidx/releases/benchmark) module (`:microbenchmark`) that measures the performance of all three syntax highlighting libraries.
+
+## What's Benchmarked
+
+| Class | Library | What it Measures |
+|-------|---------|-----------------|
+| `TextMateHighlightBenchmark` | kotlin-textmate | `CodeHighlighter.highlight(code)` — CPU tokenization per language and code size |
+| `TextMateGrammarLoadBenchmark` | kotlin-textmate | Grammar parsing and theme loading from assets (one-time startup cost) |
+| `ShikiAnnotationBenchmark` | Shiki SDK | `buildAnnotatedString` from token data — the CPU cost of converting tokens to `AnnotatedString` |
+| `ComposeHighlightBenchmark` | compose-highlight | `HighlightEngine.highlightBothThemes()` — full WebView JS round-trip |
+
+### Benchmark Dimensions
+
+- **Language**: Kotlin, Python, JSON, JavaScript
+- **Code size**: small (~25 lines), medium (~100 lines), large (~1000 lines)
+- **Theme**: Dark (VS Dark+, One Dark Pro, Monokai), Light (VS Light+)
+
+## Running Benchmarks
+
+### On a Physical Device (recommended)
+
+For accurate results, benchmarks must run on a physical device with a non-debuggable build:
+
+```bash
+./gradlew :microbenchmark:connectedReleaseAndroidTest
+```
+
+### Dry-Run on Emulator
+
+To verify benchmarks compile and execute (results will not be accurate):
+
+```bash
+./gradlew :microbenchmark:connectedReleaseAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.dryRunMode.enable=true
+```
+
+### Run a Single Benchmark Class
+
+```bash
+./gradlew :microbenchmark:connectedReleaseAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=dev.hossain.benchmark.TextMateHighlightBenchmark
+```
+
+## Generating the Report
+
+After running benchmarks, generate a Markdown comparison table:
+
+```bash
+python3 scripts/benchmark_report.py
+```
+
+This reads the JSON output from:
+```
+microbenchmark/build/outputs/connected_android_test_additional_output/
+```
+
+And writes `BENCHMARK_RESULTS.md` at the project root.
+
+You can also pass a specific JSON file:
+```bash
+python3 scripts/benchmark_report.py path/to/benchmarkData.json
+```
+
+## Output Format
+
+The AndroidX Benchmark library produces a JSON file with per-benchmark timing stats (median, min, max, iterations, warmup). The report script parses this and produces a table grouped by library.
+
+## Notes
+
+- **Physical device**: Emulator results are unreliable and suppressed by default. Use a real device for publishable numbers.
+- **CPU clocks**: For best stability on rooted devices, lock clocks with `./gradlew :microbenchmark:lockClocks`.
+- **WebView benchmarks** (`ComposeHighlightBenchmark`): These involve WebView JS bridge calls and are inherently noisier than pure CPU benchmarks. The first run includes WebView initialization; subsequent iterations reflect steady-state performance.
+- **Battery**: Ensure at least 25% battery to avoid throttling warnings.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
     // Project: https://developer.android.com/build
     alias(libs.plugins.android.application) apply false
 
+    // Applies the Android library plugin (used by :microbenchmark module).
+    alias(libs.plugins.android.library) apply false
+
     // Kotlin support is built into AGP 9.1+ - kotlin-android plugin is no longer needed
     // See: https://developer.android.com/build/migrate-to-built-in-kotlin
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,9 @@ lifecycleRuntimeKtx = "2.10.0"
 metro = "1.0.0"
 androidxWebkit = "1.16.0"
 
+# https://developer.android.com/jetpack/androidx/releases/benchmark
+benchmarkJunit4 = "1.4.1"
+
 # https://github.com/hossain-khan/android-compose-highlight
 composeHighlight = "0.19.0"
 
@@ -56,6 +59,10 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+
+# AndroidX Benchmark - Microbenchmark
+# https://developer.android.com/jetpack/androidx/releases/benchmark
+androidx-benchmark-junit4 = { group = "androidx.benchmark", name = "benchmark-junit4", version.ref = "benchmarkJunit4" }
 
 # Circuit - ⚡️A Compose-driven architecture for Kotlin and Android applications.
 # https://github.com/slackhq/circuit/releases
@@ -93,6 +100,7 @@ kotlin-textmate-compose = { group = "io.github.ivan-magda", name = "kotlin-textm
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
+android-library = { id = "com.android.library", version.ref = "agp" }
 # kotlin-android plugin is no longer needed with AGP 9.1+ (built-in Kotlin support)
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }

--- a/microbenchmark/build.gradle.kts
+++ b/microbenchmark/build.gradle.kts
@@ -1,0 +1,56 @@
+plugins {
+    alias(libs.plugins.android.library)
+}
+
+android {
+    namespace = "dev.hossain.benchmark"
+    compileSdk = libs.versions.compileSdk.get().toInt()
+
+    defaultConfig {
+        minSdk = libs.versions.minSdk.get().toInt()
+        testInstrumentationRunner = "androidx.benchmark.junit4.AndroidBenchmarkRunner"
+
+        // Suppress EMULATOR error to allow dry-run on emulators; remove for real device runs
+        testInstrumentationRunnerArguments["androidx.benchmark.suppressErrors"] = "EMULATOR"
+    }
+
+    // Benchmarks must run against a non-debuggable build for accurate timing
+    testBuildType = "release"
+
+    buildTypes {
+        debug {
+            // Keep debug for development, but benchmarks use release
+        }
+        release {
+            isMinifyEnabled = false
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+}
+
+dependencies {
+    // AndroidX Benchmark
+    androidTestImplementation(libs.androidx.benchmark.junit4)
+
+    // Test framework
+    androidTestImplementation(libs.junit)
+    androidTestImplementation(libs.androidx.junit)
+
+    // Libraries under benchmark
+    androidTestImplementation(libs.kotlin.textmate.compose)
+    androidTestImplementation(libs.shiki.sdk)
+    androidTestImplementation(libs.compose.highlight)
+
+    // Compose UI text (AnnotatedString, SpanStyle, Color)
+    androidTestImplementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation(libs.androidx.ui)
+
+    // For ActivityScenario (compose-highlight WebView benchmark)
+    androidTestImplementation(libs.androidx.activity.compose)
+    androidTestImplementation("androidx.test:core:1.6.1")
+    androidTestImplementation("androidx.test:runner:1.6.2")
+}

--- a/microbenchmark/src/androidTest/assets/grammars/JSON.tmLanguage.json
+++ b/microbenchmark/src/androidTest/assets/grammars/JSON.tmLanguage.json
@@ -1,0 +1,213 @@
+{
+	"information_for_contributors": [
+		"This file has been converted from https://github.com/microsoft/vscode-JSON.tmLanguage/blob/master/JSON.tmLanguage",
+		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
+		"Once accepted there, we are happy to receive an update request."
+	],
+	"version": "https://github.com/microsoft/vscode-JSON.tmLanguage/commit/9bd83f1c252b375e957203f21793316203f61f70",
+	"name": "JSON (Javascript Next)",
+	"scopeName": "source.json",
+	"patterns": [
+		{
+			"include": "#value"
+		}
+	],
+	"repository": {
+		"array": {
+			"begin": "\\[",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.array.begin.json"
+				}
+			},
+			"end": "\\]",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.array.end.json"
+				}
+			},
+			"name": "meta.structure.array.json",
+			"patterns": [
+				{
+					"include": "#value"
+				},
+				{
+					"match": ",",
+					"name": "punctuation.separator.array.json"
+				},
+				{
+					"match": "[^\\s\\]]",
+					"name": "invalid.illegal.expected-array-separator.json"
+				}
+			]
+		},
+		"comments": {
+			"patterns": [
+				{
+					"begin": "/\\*\\*(?!/)",
+					"captures": {
+						"0": {
+							"name": "punctuation.definition.comment.json"
+						}
+					},
+					"end": "\\*/",
+					"name": "comment.block.documentation.json"
+				},
+				{
+					"begin": "/\\*",
+					"captures": {
+						"0": {
+							"name": "punctuation.definition.comment.json"
+						}
+					},
+					"end": "\\*/",
+					"name": "comment.block.json"
+				},
+				{
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.comment.json"
+						}
+					},
+					"match": "(//).*$\\n?",
+					"name": "comment.line.double-slash.js"
+				}
+			]
+		},
+		"constant": {
+			"match": "\\b(?:true|false|null)\\b",
+			"name": "constant.language.json"
+		},
+		"number": {
+			"match": "(?x)        # turn on extended mode\n  -?        # an optional minus\n  (?:\n    0       # a zero\n    |       # ...or...\n    [1-9]   # a 1-9 character\n    \\d*     # followed by zero or more digits\n  )\n  (?:\n    (?:\n      \\.    # a period\n      \\d+   # followed by one or more digits\n    )?\n    (?:\n      [eE]  # an e character\n      [+-]? # followed by an option +/-\n      \\d+   # followed by one or more digits\n    )?      # make exponent optional\n  )?        # make decimal portion optional",
+			"name": "constant.numeric.json"
+		},
+		"object": {
+			"begin": "\\{",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.dictionary.begin.json"
+				}
+			},
+			"end": "\\}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.dictionary.end.json"
+				}
+			},
+			"name": "meta.structure.dictionary.json",
+			"patterns": [
+				{
+					"comment": "the JSON object key",
+					"include": "#objectkey"
+				},
+				{
+					"include": "#comments"
+				},
+				{
+					"begin": ":",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.separator.dictionary.key-value.json"
+						}
+					},
+					"end": "(,)|(?=\\})",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.separator.dictionary.pair.json"
+						}
+					},
+					"name": "meta.structure.dictionary.value.json",
+					"patterns": [
+						{
+							"comment": "the JSON object value",
+							"include": "#value"
+						},
+						{
+							"match": "[^\\s,]",
+							"name": "invalid.illegal.expected-dictionary-separator.json"
+						}
+					]
+				},
+				{
+					"match": "[^\\s\\}]",
+					"name": "invalid.illegal.expected-dictionary-separator.json"
+				}
+			]
+		},
+		"string": {
+			"begin": "\"",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.json"
+				}
+			},
+			"end": "\"",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.end.json"
+				}
+			},
+			"name": "string.quoted.double.json",
+			"patterns": [
+				{
+					"include": "#stringcontent"
+				}
+			]
+		},
+		"objectkey": {
+			"begin": "\"",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.support.type.property-name.begin.json"
+				}
+			},
+			"end": "\"",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.support.type.property-name.end.json"
+				}
+			},
+			"name": "string.json support.type.property-name.json",
+			"patterns": [
+				{
+					"include": "#stringcontent"
+				}
+			]
+		},
+		"stringcontent": {
+			"patterns": [
+				{
+					"match": "(?x)                # turn on extended mode\n  \\\\                # a literal backslash\n  (?:               # ...followed by...\n    [\"\\\\/bfnrt]     # one of these characters\n    |               # ...or...\n    u               # a u\n    [0-9a-fA-F]{4}) # and four hex digits",
+					"name": "constant.character.escape.json"
+				},
+				{
+					"match": "\\\\.",
+					"name": "invalid.illegal.unrecognized-string-escape.json"
+				}
+			]
+		},
+		"value": {
+			"patterns": [
+				{
+					"include": "#constant"
+				},
+				{
+					"include": "#number"
+				},
+				{
+					"include": "#string"
+				},
+				{
+					"include": "#array"
+				},
+				{
+					"include": "#object"
+				},
+				{
+					"include": "#comments"
+				}
+			]
+		}
+	}
+}

--- a/microbenchmark/src/androidTest/assets/grammars/JavaScript.tmLanguage.json
+++ b/microbenchmark/src/androidTest/assets/grammars/JavaScript.tmLanguage.json
@@ -1,0 +1,3575 @@
+{
+	"name": "JavaScript (with React support)",
+	"scopeName": "source.js",
+	"fileTypes": [
+		".js",
+		".jsx"
+	],
+	"uuid": "805375ec-d614-41f5-8993-5843fe63ea82",
+	"patterns": [
+		{
+			"include": "#directives"
+		},
+		{
+			"include": "#statements"
+		},
+		{
+			"name": "comment.line.shebang.ts",
+			"match": "\\A(#!).*(?=$)",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.comment.ts"
+				}
+			}
+		}
+	],
+	"repository": {
+		"statements": {
+			"patterns": [
+				{
+					"include": "#string"
+				},
+				{
+					"include": "#template"
+				},
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#literal"
+				},
+				{
+					"include": "#declaration"
+				},
+				{
+					"include": "#switch-statement"
+				},
+				{
+					"include": "#for-loop"
+				},
+				{
+					"include": "#after-operator-block"
+				},
+				{
+					"include": "#decl-block"
+				},
+				{
+					"include": "#control-statement"
+				},
+				{
+					"include": "#expression"
+				},
+				{
+					"include": "#punctuation-semicolon"
+				}
+			]
+		},
+		"var-expr": {
+			"name": "meta.var.expr.js",
+			"begin": "(?<!\\.|\\$)(?:(\\bexport)\\s+)?\\b(var|let|const(?!\\s+enum\\b))\\b(?!\\$)",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.export.js"
+				},
+				"2": {
+					"name": "storage.type.js"
+				}
+			},
+			"end": "(?=$|;|}|(\\s+(of|in)\\s+))",
+			"patterns": [
+				{
+					"include": "#destructuring-variable"
+				},
+				{
+					"include": "#var-single-variable"
+				},
+				{
+					"include": "#variable-initializer"
+				},
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#punctuation-comma"
+				}
+			]
+		},
+		"var-single-variable": {
+			"patterns": [
+				{
+					"name": "meta.var-single-variable.expr.js",
+					"begin": "(?x)([_$[:alpha:]][_$[:alnum:]]*)(?=\\s* (=\\s*( (async\\s+) | (function\\s*[(<]) | (function\\s+) | ([_$[:alpha:]][_$[:alnum:]]*\\s*=>) | ((<([^<>]|\\<[^<>]+\\>)+>\\s*)?\\(([^()]|\\([^()]*\\))*\\)(\\s*:\\s*(.)*)?\\s*=>)) ) | (:\\s*( (<) | ([(]\\s*( ([)]) | (\\.\\.\\.) | ([_$[:alnum:]]+\\s*( ([:,?=])| ([)]\\s*=>) )) ))) ))",
+					"beginCaptures": {
+						"1": {
+							"name": "entity.name.function.js"
+						}
+					},
+					"end": "(?=$|[;,=}]|(\\s+(of|in)\\s+))",
+					"patterns": [
+						{
+							"include": "#type-annotation"
+						},
+						{
+							"include": "#string"
+						},
+						{
+							"include": "#comment"
+						}
+					]
+				},
+				{
+					"name": "meta.var-single-variable.expr.js",
+					"begin": "([_$[:alpha:]][_$[:alnum:]]*)",
+					"beginCaptures": {
+						"1": {
+							"name": "variable.other.readwrite.js"
+						}
+					},
+					"end": "(?=$|[;,=}]|(\\s+(of|in)\\s+))",
+					"patterns": [
+						{
+							"include": "#type-annotation"
+						},
+						{
+							"include": "#string"
+						},
+						{
+							"include": "#comment"
+						}
+					]
+				}
+			]
+		},
+		"destructuring-variable": {
+			"patterns": [
+				{
+					"name": "meta.object-binding-pattern-variable.js",
+					"begin": "(?<!=|:|of|in)\\s*(?=\\{)",
+					"end": "(?=$|[;,=}]|(\\s+(of|in)\\s+))",
+					"patterns": [
+						{
+							"include": "#object-binding-pattern"
+						},
+						{
+							"include": "#type-annotation"
+						},
+						{
+							"include": "#comment"
+						}
+					]
+				},
+				{
+					"name": "meta.array-binding-pattern-variable.js",
+					"begin": "(?<!=|:|of|in)\\s*(?=\\[)",
+					"end": "(?=$|[;,=}]|(\\s+(of|in)\\s+))",
+					"patterns": [
+						{
+							"include": "#array-binding-pattern"
+						},
+						{
+							"include": "#type-annotation"
+						},
+						{
+							"include": "#comment"
+						}
+					]
+				}
+			]
+		},
+		"object-binding-element": {
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"begin": "(?=(([_$[:alpha:]][_$[:alnum:]]*)|(\\'[^']*\\')|(\\\"[^\"]*\\\")|(\\[([^\\[\\]]|\\[[^\\[\\]]+\\])+\\]))\\s*(:))",
+					"end": "(?=,|\\})",
+					"patterns": [
+						{
+							"include": "#object-binding-element-propertyName"
+						},
+						{
+							"include": "#binding-element"
+						}
+					]
+				},
+				{
+					"include": "#object-binding-pattern"
+				},
+				{
+					"include": "#destructuring-variable-rest"
+				},
+				{
+					"include": "#variable-initializer"
+				},
+				{
+					"include": "#punctuation-comma"
+				}
+			]
+		},
+		"object-binding-element-propertyName": {
+			"begin": "(?=(([_$[:alpha:]][_$[:alnum:]]*)|(\\'[^']*\\')|(\\\"[^\"]*\\\")|(\\[([^\\[\\]]|\\[[^\\[\\]]+\\])+\\]))\\s*(:))",
+			"end": "(:)",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.destructuring.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#string"
+				},
+				{
+					"include": "#array-literal"
+				},
+				{
+					"name": "variable.object.property.js",
+					"match": "([_$[:alpha:]][_$[:alnum:]]*)"
+				}
+			]
+		},
+		"binding-element": {
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#object-binding-pattern"
+				},
+				{
+					"include": "#array-binding-pattern"
+				},
+				{
+					"include": "#destructuring-variable-rest"
+				},
+				{
+					"include": "#variable-initializer"
+				}
+			]
+		},
+		"destructuring-variable-rest": {
+			"match": "(?:(\\.\\.\\.)\\s*)?([_$[:alpha:]][_$[:alnum:]]*)",
+			"captures": {
+				"1": {
+					"name": "keyword.operator.rest.js"
+				},
+				"2": {
+					"name": "variable.other.readwrite.js"
+				}
+			}
+		},
+		"object-binding-pattern": {
+			"begin": "(?:(\\.\\.\\.)\\s*)?(\\{)",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.operator.rest.js"
+				},
+				"2": {
+					"name": "punctuation.definition.binding-pattern.object.js"
+				}
+			},
+			"end": "\\}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.binding-pattern.object.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#object-binding-element"
+				}
+			]
+		},
+		"array-binding-pattern": {
+			"begin": "(?:(\\.\\.\\.)\\s*)?(\\[)",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.operator.rest.js"
+				},
+				"2": {
+					"name": "punctuation.definition.binding-pattern.array.js"
+				}
+			},
+			"end": "\\]",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.binding-pattern.array.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#binding-element"
+				},
+				{
+					"include": "#punctuation-comma"
+				}
+			]
+		},
+		"ternary-expression": {
+			"begin": "(?=\\?)",
+			"end": "(?=$|[;,})\\]])",
+			"patterns": [
+				{
+					"include": "#ternary-operator"
+				},
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"ternary-operator": {
+			"begin": "(\\?)",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.ternary.js"
+				}
+			},
+			"end": "(:)",
+			"endCaptures": {
+				"0": {
+					"name": "keyword.operator.ternary.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"expression": {
+			"name": "meta.expression.js",
+			"patterns": [
+				{
+					"include": "#jsx"
+				},
+				{
+					"include": "#string"
+				},
+				{
+					"include": "#regex"
+				},
+				{
+					"include": "#template"
+				},
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#literal"
+				},
+				{
+					"include": "#function-declaration"
+				},
+				{
+					"include": "#class-or-interface-declaration"
+				},
+				{
+					"include": "#arrow-function"
+				},
+				{
+					"include": "#cast"
+				},
+				{
+					"include": "#ternary-expression"
+				},
+				{
+					"include": "#new-expr"
+				},
+				{
+					"include": "#object-literal"
+				},
+				{
+					"include": "#expression-operators"
+				},
+				{
+					"include": "#function-call"
+				},
+				{
+					"include": "#support-objects"
+				},
+				{
+					"include": "#identifiers"
+				},
+				{
+					"include": "#paren-expression"
+				},
+				{
+					"include": "#punctuation-comma"
+				},
+				{
+					"include": "#punctuation-accessor"
+				}
+			]
+		},
+		"control-statement": {
+			"patterns": [
+				{
+					"name": "keyword.control.trycatch.js",
+					"match": "(?<!\\.|\\$)\\b(catch|finally|throw|try)\\b(?!\\$)"
+				},
+				{
+					"name": "keyword.control.loop.js",
+					"match": "(?<!\\.|\\$)\\b(break|continue|do|goto|while)\\b(?!\\$)"
+				},
+				{
+					"name": "keyword.control.flow.js",
+					"match": "(?<!\\.|\\$)\\b(return)\\b(?!\\$)"
+				},
+				{
+					"match": "(?<!\\.|\\$)\\b(yield)\\b(?!\\$)(?:\\s*(\\*))?",
+					"captures": {
+						"1": {
+							"name": "keyword.control.flow.js"
+						},
+						"2": {
+							"name": "keyword.generator.asterisk.js"
+						}
+					}
+				},
+				{
+					"name": "keyword.control.switch.js",
+					"match": "(?<!\\.|\\$)\\b(case|default|switch)\\b(?!\\$)"
+				},
+				{
+					"name": "keyword.control.conditional.js",
+					"match": "(?<!\\.|\\$)\\b(else|if)\\b(?!\\$)"
+				},
+				{
+					"name": "keyword.control.with.js",
+					"match": "(?<!\\.|\\$)\\b(with)\\b(?!\\$)"
+				},
+				{
+					"name": "keyword.other.debugger.js",
+					"match": "(?<!\\.|\\$)\\b(debugger)\\b(?!\\$)"
+				},
+				{
+					"name": "storage.modifier.js",
+					"match": "(?<!\\.|\\$)\\b(declare)\\b(?!\\$)"
+				}
+			]
+		},
+		"declaration": {
+			"name": "meta.declaration.js",
+			"patterns": [
+				{
+					"include": "#decorator"
+				},
+				{
+					"include": "#var-expr"
+				},
+				{
+					"include": "#function-declaration"
+				},
+				{
+					"include": "#class-or-interface-declaration"
+				},
+				{
+					"include": "#type-declaration"
+				},
+				{
+					"include": "#enum-declaration"
+				},
+				{
+					"include": "#namespace-declaration"
+				},
+				{
+					"include": "#import-equals-declaration"
+				},
+				{
+					"include": "#import-declaration"
+				},
+				{
+					"include": "#export-declaration"
+				}
+			]
+		},
+		"decorator": {
+			"name": "meta.decorator.js",
+			"begin": "(?<!\\.|\\$)\\@",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.decorator.js"
+				}
+			},
+			"end": "(?=\\s)",
+			"patterns": [
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"type-declaration": {
+			"name": "meta.type.declaration.js",
+			"begin": "(?<!\\.|\\$)(?:(\\bexport)\\s+)?\\b(type)\\b\\s+([_$[:alpha:]][_$[:alnum:]]*)\\s*",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.export.js"
+				},
+				"2": {
+					"name": "storage.type.type.js"
+				},
+				"3": {
+					"name": "entity.name.type.js"
+				}
+			},
+			"end": "(?=[};]|\\bvar\\b|\\blet\\b|\\bconst\\b|\\btype\\b|\\bfunction\\b|\\bclass\\b|\\binterface\\b|\\bnamespace\\b|\\bmodule\\b|\\bimport\\b|\\benum\\b|\\bdeclare\\b|\\bexport\\b|\\babstract\\b|\\basync\\b)",
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#type-parameters"
+				},
+				{
+					"include": "#type"
+				},
+				{
+					"match": "(=)\\s*",
+					"captures": {
+						"1": {
+							"name": "keyword.operator.assignment.js"
+						}
+					}
+				}
+			]
+		},
+		"enum-declaration": {
+			"name": "meta.enum.declaration.js",
+			"begin": "(?<!\\.|\\$)(?:(\\bexport)\\s+)?(?:\\b(const)\\s+)?\\b(enum)\\s+([_$[:alpha:]][_$[:alnum:]]*)",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.export.js"
+				},
+				"2": {
+					"name": "storage.modifier.js"
+				},
+				"3": {
+					"name": "storage.type.enum.js"
+				},
+				"4": {
+					"name": "entity.name.type.enum.js"
+				}
+			},
+			"end": "(?<=\\})",
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"begin": "\\{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.block.js"
+						}
+					},
+					"end": "\\}",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.block.js"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#comment"
+						},
+						{
+							"begin": "([_$[:alpha:]][_$[:alnum:]]*)",
+							"beginCaptures": {
+								"0": {
+									"name": "variable.other.enummember.js"
+								}
+							},
+							"end": "(?=,|\\}|$)",
+							"patterns": [
+								{
+									"include": "#comment"
+								},
+								{
+									"include": "#variable-initializer"
+								}
+							]
+						},
+						{
+							"begin": "(?=((\\'[^']*\\')|(\\\"[^\"]*\\\")|(\\[([^\\[\\]]|\\[[^\\[\\]]+\\])+\\])))",
+							"end": "(?=,|\\}|$)",
+							"patterns": [
+								{
+									"include": "#string"
+								},
+								{
+									"include": "#array-literal"
+								},
+								{
+									"include": "#comment"
+								},
+								{
+									"include": "#variable-initializer"
+								}
+							]
+						},
+						{
+							"include": "#punctuation-comma"
+						}
+					]
+				}
+			]
+		},
+		"namespace-declaration": {
+			"name": "meta.namespace.declaration.js",
+			"begin": "(?<!\\.|\\$)(?:(\\bexport)\\s+)?\\b(namespace|module)\\s+",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.export.js"
+				},
+				"2": {
+					"name": "storage.type.namespace.js"
+				}
+			},
+			"end": "(?=$|\\{)",
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#string"
+				},
+				{
+					"name": "entity.name.type.module.js",
+					"match": "([_$[:alpha:]][_$[:alnum:]]*)"
+				},
+				{
+					"name": "punctuation.accessor.js",
+					"match": "\\."
+				}
+			]
+		},
+		"import-equals-declaration": {
+			"patterns": [
+				{
+					"name": "meta.import-equals.external.js",
+					"begin": "(?<!\\.|\\$)(?:(\\bexport)\\s+)?\\b(import)\\s+([_$[:alpha:]][_$[:alnum:]]*)\\s*(=)\\s*(require)\\s*(\\()",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.control.export.js"
+						},
+						"2": {
+							"name": "keyword.control.import.js"
+						},
+						"3": {
+							"name": "variable.other.readwrite.alias.js"
+						},
+						"4": {
+							"name": "keyword.operator.assignment.js"
+						},
+						"5": {
+							"name": "keyword.control.require.js"
+						},
+						"6": {
+							"name": "meta.brace.round.js"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "meta.brace.round.js"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#comment"
+						},
+						{
+							"include": "#string"
+						}
+					]
+				},
+				{
+					"name": "meta.import-equals.internal.js",
+					"begin": "(?<!\\.|\\$)(?:(\\bexport)\\s+)?\\b(import)\\s+([_$[:alpha:]][_$[:alnum:]]*)\\s*(=)\\s*(?!require\\b)",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.control.export.js"
+						},
+						"2": {
+							"name": "keyword.control.import.js"
+						},
+						"3": {
+							"name": "variable.other.readwrite.alias.js"
+						},
+						"4": {
+							"name": "keyword.operator.assignment.js"
+						}
+					},
+					"end": "(?=;|$)",
+					"patterns": [
+						{
+							"include": "#comment"
+						},
+						{
+							"match": "([_$[:alpha:]][_$[:alnum:]]*)\\s*(\\.)",
+							"captures": {
+								"1": {
+									"name": "entity.name.type.module.js"
+								},
+								"2": {
+									"name": "punctuation.accessor.js"
+								}
+							}
+						},
+						{
+							"name": "variable.other.readwrite.js",
+							"match": "([_$[:alpha:]][_$[:alnum:]]*)"
+						}
+					]
+				}
+			]
+		},
+		"import-declaration": {
+			"name": "meta.import.js",
+			"begin": "(?<!\\.|\\$)(?:(\\bexport)\\s+)?\\b(import)(?!(\\s*:)|(\\$))\\b",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.export.js"
+				},
+				"2": {
+					"name": "keyword.control.import.js"
+				}
+			},
+			"end": "(?=;|$)",
+			"patterns": [
+				{
+					"include": "#import-export-declaration"
+				}
+			]
+		},
+		"export-declaration": {
+			"patterns": [
+				{
+					"match": "(?<!\\.|\\$)\\b(export)\\s+(as)\\s+(namespace)\\s+([_$[:alpha:]][_$[:alnum:]]*)",
+					"captures": {
+						"1": {
+							"name": "keyword.control.export.js"
+						},
+						"2": {
+							"name": "keyword.control.as.js"
+						},
+						"3": {
+							"name": "storage.type.namespace.js"
+						},
+						"4": {
+							"name": "entity.name.type.module.js"
+						}
+					}
+				},
+				{
+					"name": "meta.export.default.js",
+					"begin": "(?<!\\.|\\$)\\b(export)(?:(?:\\s*(=))|(?:\\s+(default)(?=\\s+)))",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.control.export.js"
+						},
+						"2": {
+							"name": "keyword.operator.assignment.js"
+						},
+						"3": {
+							"name": "keyword.control.default.js"
+						}
+					},
+					"end": "(?=;|\\bexport\\b|\\bfunction\\b|\\bclass\\b|\\binterface\\b|\\blet\\b|\\bvar\\b|\\bconst\\b|\\bimport\\b|\\benum\\b|\\bnamespace\\b|\\bmodule\\b|\\btype\\b|\\babstract\\b|\\bdeclare\\b|\\basync\\b|$)",
+					"patterns": [
+						{
+							"include": "#expression"
+						}
+					]
+				},
+				{
+					"name": "meta.export.js",
+					"begin": "(?<!\\.|\\$)\\b(export)(?!(\\s*:)|(\\$))\\b",
+					"beginCaptures": {
+						"0": {
+							"name": "keyword.control.export.js"
+						}
+					},
+					"end": "(?=;|\\bexport\\b|\\bfunction\\b|\\bclass\\b|\\binterface\\b|\\blet\\b|\\bvar\\b|\\bconst\\b|\\bimport\\b|\\benum\\b|\\bnamespace\\b|\\bmodule\\b|\\btype\\b|\\babstract\\b|\\bdeclare\\b|\\basync\\b|$)",
+					"patterns": [
+						{
+							"include": "#import-export-declaration"
+						}
+					]
+				}
+			]
+		},
+		"import-export-declaration": {
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#string"
+				},
+				{
+					"include": "#import-export-block"
+				},
+				{
+					"name": "keyword.control.from.js",
+					"match": "\\bfrom\\b"
+				},
+				{
+					"include": "#import-export-clause"
+				}
+			]
+		},
+		"import-export-block": {
+			"name": "meta.block.js",
+			"begin": "\\{",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.block.js"
+				}
+			},
+			"end": "\\}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.block.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#import-export-clause"
+				}
+			]
+		},
+		"import-export-clause": {
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"comment": "(default|*|name) as alias",
+					"match": "(?x) (?: \\b(default)\\b | (\\*) | ([_$[:alpha:]][_$[:alnum:]]*)) \\s+  (as) \\s+ (?: (\\b default \\b | \\*) | ([_$[:alpha:]][_$[:alnum:]]*))",
+					"captures": {
+						"1": {
+							"name": "keyword.control.default.js"
+						},
+						"2": {
+							"name": "constant.language.import-export-all.js"
+						},
+						"3": {
+							"name": "variable.other.readwrite.js"
+						},
+						"4": {
+							"name": "keyword.control.as.js"
+						},
+						"5": {
+							"name": "invalid.illegal.js"
+						},
+						"6": {
+							"name": "variable.other.readwrite.alias.js"
+						}
+					}
+				},
+				{
+					"include": "#punctuation-comma"
+				},
+				{
+					"name": "constant.language.import-export-all.js",
+					"match": "\\*"
+				},
+				{
+					"name": "keyword.control.default.js",
+					"match": "\\b(default)\\b"
+				},
+				{
+					"name": "variable.other.readwrite.alias.js",
+					"match": "([_$[:alpha:]][_$[:alnum:]]*)"
+				}
+			]
+		},
+		"class-or-interface-declaration": {
+			"name": "meta.class.js",
+			"begin": "(?<!\\.|\\$)\\b(?:(export)\\s+)?\\b(?:(abstract)\\s+)?\\b(?:(class)|(interface))\\b",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.export.js"
+				},
+				"2": {
+					"name": "storage.modifier.js"
+				},
+				"3": {
+					"name": "storage.type.class.js"
+				},
+				"4": {
+					"name": "storage.type.interface.js"
+				}
+			},
+			"end": "(?<=\\})",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.block.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#class-or-interface-heritage"
+				},
+				{
+					"match": "[_$[:alpha:]][_$[:alnum:]]*",
+					"captures": {
+						"0": {
+							"name": "entity.name.type.class.js"
+						}
+					}
+				},
+				{
+					"include": "#type-parameters"
+				},
+				{
+					"include": "#class-or-interface-body"
+				}
+			]
+		},
+		"class-or-interface-heritage": {
+			"begin": "(?<!\\.|\\$)(?:\\b(extends|implements)\\b)(?!\\$)",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.modifier.js"
+				}
+			},
+			"end": "(?=\\{)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.block.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#class-or-interface-heritage"
+				},
+				{
+					"include": "#type-parameters"
+				},
+				{
+					"match": "([_$[:alpha:]][_$[:alnum:]]*)\\s*(\\.)(?=\\s*[_$[:alpha:]][_$[:alnum:]]*(\\s*\\.\\s*[_$[:alpha:]][_$[:alnum:]]*)*\\s*([,<{]|extends|implements|//|/\\*))",
+					"captures": {
+						"1": {
+							"name": "entity.name.type.module.js"
+						},
+						"2": {
+							"name": "punctuation.accessor.js"
+						}
+					}
+				},
+				{
+					"match": "([_$[:alpha:]][_$[:alnum:]]*)(?=\\s*([,<{]|extends|implements|//|/\\*))",
+					"captures": {
+						"1": {
+							"name": "entity.other.inherited-class.js"
+						}
+					}
+				},
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"class-or-interface-body": {
+			"begin": "\\{",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.block.js"
+				}
+			},
+			"end": "\\}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.block.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#string"
+				},
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#decorator"
+				},
+				{
+					"include": "#method-declaration"
+				},
+				{
+					"include": "#indexer-declaration"
+				},
+				{
+					"include": "#field-declaration"
+				},
+				{
+					"include": "#type-annotation"
+				},
+				{
+					"include": "#variable-initializer"
+				},
+				{
+					"include": "#access-modifier"
+				},
+				{
+					"include": "#property-accessor"
+				},
+				{
+					"include": "#expression"
+				},
+				{
+					"include": "#punctuation-comma"
+				},
+				{
+					"include": "#punctuation-semicolon"
+				}
+			]
+		},
+		"type-object": {
+			"name": "meta.object.type.js",
+			"begin": "\\{",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.block.js"
+				}
+			},
+			"end": "\\}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.block.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#type-object-members"
+				}
+			]
+		},
+		"type-object-members": {
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#method-declaration"
+				},
+				{
+					"include": "#indexer-declaration"
+				},
+				{
+					"include": "#field-declaration"
+				},
+				{
+					"include": "#type-annotation"
+				},
+				{
+					"begin": "\\.\\.\\.",
+					"beginCaptures": {
+						"0": {
+							"name": "keyword.operator.spread.js"
+						}
+					},
+					"end": "(?=\\}|;|,|$)|(?<=\\})",
+					"patterns": [
+						{
+							"include": "#type"
+						}
+					]
+				},
+				{
+					"include": "#punctuation-comma"
+				},
+				{
+					"include": "#punctuation-semicolon"
+				}
+			]
+		},
+		"field-declaration": {
+			"name": "meta.field.declaration.js",
+			"begin": "(?<!\\()(?:(?<!\\.|\\$)\\b(readonly)\\s+)?(?=(([_$[:alpha:]][_$[:alnum:]]*)|(\\'[^']*\\')|(\\\"[^\"]*\\\")|(\\[([^\\[\\]]|\\[[^\\[\\]]+\\])+\\]))\\s*(\\?\\s*)?(=|:))",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.modifier.js"
+				}
+			},
+			"end": "(?=\\}|;|,|$)|(?<=\\})",
+			"patterns": [
+				{
+					"include": "#variable-initializer"
+				},
+				{
+					"begin": "(?=((?:[_$[:alpha:]][_$[:alnum:]]*)|(?:\\'[^']*\\')|(?:\\\"[^\"]*\\\")|(\\[([^\\[\\]]|\\[[^\\[\\]]+\\])+\\]))\\s*(\\?\\s*)?(=|:))",
+					"end": "(?=[};,=]|$)|(?<=\\})",
+					"patterns": [
+						{
+							"include": "#type-annotation"
+						},
+						{
+							"include": "#string"
+						},
+						{
+							"include": "#array-literal"
+						},
+						{
+							"include": "#comment"
+						},
+						{
+							"name": "entity.name.function.js",
+							"match": "(?x)([_$[:alpha:]][_$[:alnum:]]*)(?=(\\?\\s*)?\\s* (=\\s*( (async\\s+) | (function\\s*[(<]) | (function\\s+) | ([_$[:alpha:]][_$[:alnum:]]*\\s*=>) | ((<([^<>]|\\<[^<>]+\\>)+>\\s*)?\\(([^()]|\\([^()]*\\))*\\)(\\s*:\\s*(.)*)?\\s*=>)) ) | (:\\s*( (<) | ([(]\\s*( ([)]) | (\\.\\.\\.) | ([_$[:alnum:]]+\\s*( ([:,?=])| ([)]\\s*=>) )) ))) ))"
+						},
+						{
+							"name": "variable.object.property.js",
+							"match": "[_$[:alpha:]][_$[:alnum:]]*"
+						},
+						{
+							"name": "keyword.operator.optional.js",
+							"match": "\\?"
+						}
+					]
+				}
+			]
+		},
+		"method-declaration": {
+			"name": "meta.method.declaration.js",
+			"begin": "(?<!\\.|\\$)(?:\\b(public|private|protected)\\s+)?(?:\\b(abstract)\\s+)?(?:\\b(async)\\s+)?(?:\\b(get|set)\\s+)?(?:(?:\\b(?:(new)|(constructor))\\b(?!\\$|:))|(?:(\\*)\\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\\'[^']*\\')|(\\\"[^\"]*\\\")|(\\[([^\\[\\]]|\\[[^\\[\\]]+\\])+\\]))\\s*(\\??))?\\s*[\\(\\<]))",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.modifier.js"
+				},
+				"2": {
+					"name": "storage.modifier.js"
+				},
+				"3": {
+					"name": "storage.modifier.async.js"
+				},
+				"4": {
+					"name": "storage.type.property.js"
+				},
+				"5": {
+					"name": "keyword.operator.new.js"
+				},
+				"6": {
+					"name": "storage.type.js"
+				},
+				"7": {
+					"name": "keyword.generator.asterisk.js"
+				}
+			},
+			"end": "(?=\\}|;|,)|(?<=\\})",
+			"patterns": [
+				{
+					"include": "#method-declaration-name"
+				},
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#type-parameters"
+				},
+				{
+					"include": "#function-parameters"
+				},
+				{
+					"include": "#return-type"
+				},
+				{
+					"include": "#method-overload-declaration"
+				},
+				{
+					"include": "#decl-block"
+				}
+			]
+		},
+		"method-overload-declaration": {
+			"begin": "(?<!\\.|\\$)(?:\\b(public|private|protected)\\s+)?(?:\\b(abstract)\\s+)?(?:\\b(async)\\s+)?(?:\\b(get|set)\\s+)?(?:(?:\\b(?:(new)|(constructor))\\b(?!\\$|:))|(?:(\\*)\\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\\'[^']*\\')|(\\\"[^\"]*\\\")|(\\[([^\\[\\]]|\\[[^\\[\\]]+\\])+\\]))\\s*(\\??))?\\s*[\\(\\<]))",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.modifier.js"
+				},
+				"2": {
+					"name": "storage.modifier.js"
+				},
+				"3": {
+					"name": "storage.modifier.async.js"
+				},
+				"4": {
+					"name": "storage.type.property.js"
+				},
+				"5": {
+					"name": "keyword.operator.new.js"
+				},
+				"6": {
+					"name": "storage.type.js"
+				},
+				"7": {
+					"name": "keyword.generator.asterisk.js"
+				}
+			},
+			"end": "(?=\\(|\\<)",
+			"patterns": [
+				{
+					"include": "#method-declaration-name"
+				}
+			]
+		},
+		"method-declaration-name": {
+			"begin": "(?=(([_$[:alpha:]][_$[:alnum:]]*)|(\\'[^']*\\')|(\\\"[^\"]*\\\")|(\\[([^\\[\\]]|\\[[^\\[\\]]+\\])+\\]))\\s*(\\??)\\s*[\\(\\<])",
+			"end": "(?=\\(|\\<)",
+			"patterns": [
+				{
+					"include": "#string"
+				},
+				{
+					"include": "#array-literal"
+				},
+				{
+					"name": "entity.name.function.js",
+					"match": "[_$[:alpha:]][_$[:alnum:]]*"
+				},
+				{
+					"name": "keyword.operator.optional.js",
+					"match": "\\?"
+				}
+			]
+		},
+		"indexer-declaration": {
+			"name": "meta.indexer.declaration.js",
+			"begin": "(?:(?<!\\.|\\$)\\b(readonly)\\s*)?(\\[)\\s*([_$[:alpha:]][_$[:alnum:]]*)\\s*(?=:)",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.modifier.js"
+				},
+				"2": {
+					"name": "meta.brace.square.js"
+				},
+				"3": {
+					"name": "variable.parameter.js"
+				}
+			},
+			"end": "(\\])\\s*(\\?\\s*)?|$",
+			"endCaptures": {
+				"1": {
+					"name": "meta.brace.square.js"
+				},
+				"2": {
+					"name": "keyword.operator.optional.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#type-annotation"
+				}
+			]
+		},
+		"function-declaration": {
+			"name": "meta.function.js",
+			"begin": "(?<!\\.|\\$)\\b(?:(export)\\s+)?(?:(async)\\s+)?(function\\b)(?:\\s*(\\*))?(?:(?:\\s+|(?<=\\*))([_$[:alpha:]][_$[:alnum:]]*))?\\s*",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.export.js"
+				},
+				"2": {
+					"name": "storage.modifier.async.js"
+				},
+				"3": {
+					"name": "storage.type.function.js"
+				},
+				"4": {
+					"name": "keyword.generator.asterisk.js"
+				},
+				"5": {
+					"name": "entity.name.function.js"
+				}
+			},
+			"end": "(?=;|\\})|(?<=\\})",
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#type-parameters"
+				},
+				{
+					"include": "#function-parameters"
+				},
+				{
+					"include": "#return-type"
+				},
+				{
+					"include": "#function-overload-declaration"
+				},
+				{
+					"include": "#decl-block"
+				}
+			]
+		},
+		"function-overload-declaration": {
+			"name": "meta.function.overload.js",
+			"match": "(?<!\\.|\\$)\\b(?:(export)\\s+)?(?:(async)\\s+)?(function\\b)(?:\\s*(\\*))?(?:(?:\\s+|(?<=\\*))([_$[:alpha:]][_$[:alnum:]]*))?\\s*",
+			"captures": {
+				"1": {
+					"name": "keyword.control.export.js"
+				},
+				"2": {
+					"name": "storage.modifier.async.js"
+				},
+				"3": {
+					"name": "storage.type.function.js"
+				},
+				"4": {
+					"name": "keyword.generator.asterisk.js"
+				},
+				"5": {
+					"name": "entity.name.function.js"
+				}
+			}
+		},
+		"object-literal": {
+			"name": "meta.objectliteral.js",
+			"begin": "\\{",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.block.js"
+				}
+			},
+			"end": "\\}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.block.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#object-member"
+				}
+			]
+		},
+		"decl-block": {
+			"name": "meta.block.js",
+			"begin": "\\{",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.block.js"
+				}
+			},
+			"end": "\\}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.block.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"after-operator-block": {
+			"name": "meta.objectliteral.js",
+			"begin": "(?<=[=(,\\[?+!]|await|return|yield|throw|in|of|typeof|&&|\\|\\||\\*)\\s*(\\{)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.block.js"
+				}
+			},
+			"end": "\\}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.block.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#object-member"
+				}
+			]
+		},
+		"parameter-name": {
+			"patterns": [
+				{
+					"match": "(?x)(?:\\s*\\b(readonly)\\s+)?(?:\\s*\\b(public|private|protected)\\s+)?(\\.\\.\\.)?\\s*(?<!=|:)([_$[:alpha:]][_$[:alnum:]]*)\\s*(\\??)(?=\\s* (=\\s*( (async\\s+) | (function\\s*[(<]) | (function\\s+) | ([_$[:alpha:]][_$[:alnum:]]*\\s*=>) | ((<([^<>]|\\<[^<>]+\\>)+>\\s*)?\\(([^()]|\\([^()]*\\))*\\)(\\s*:\\s*(.)*)?\\s*=>)) ) | (:\\s*( (<) | ([(]\\s*( ([)]) | (\\.\\.\\.) | ([_$[:alnum:]]+\\s*( ([:,?=])| ([)]\\s*=>) )) ))) ))",
+					"captures": {
+						"1": {
+							"name": "storage.modifier.js"
+						},
+						"2": {
+							"name": "storage.modifier.js"
+						},
+						"3": {
+							"name": "keyword.operator.rest.js"
+						},
+						"4": {
+							"name": "entity.name.function.js"
+						},
+						"5": {
+							"name": "keyword.operator.optional.js"
+						}
+					}
+				},
+				{
+					"match": "(?:\\s*\\b(readonly)\\s+)?(?:\\s*\\b(public|private|protected)\\s+)?(\\.\\.\\.)?\\s*(?<!=|:)([_$[:alpha:]][_$[:alnum:]]*)\\s*(\\??)",
+					"captures": {
+						"1": {
+							"name": "storage.modifier.js"
+						},
+						"2": {
+							"name": "storage.modifier.js"
+						},
+						"3": {
+							"name": "keyword.operator.rest.js"
+						},
+						"4": {
+							"name": "variable.parameter.js"
+						},
+						"5": {
+							"name": "keyword.operator.optional.js"
+						}
+					}
+				}
+			]
+		},
+		"destructuring-parameter": {
+			"patterns": [
+				{
+					"name": "meta.parameter.object-binding-pattern.js",
+					"begin": "(?<!=|:)\\s*(\\{)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.binding-pattern.object.js"
+						}
+					},
+					"end": "\\}",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.binding-pattern.object.js"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#parameter-object-binding-element"
+						}
+					]
+				},
+				{
+					"name": "meta.paramter.array-binding-pattern.js",
+					"begin": "(?<!=|:)\\s*(\\[)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.binding-pattern.array.js"
+						}
+					},
+					"end": "\\]",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.binding-pattern.array.js"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#parameter-binding-element"
+						},
+						{
+							"include": "#punctuation-comma"
+						}
+					]
+				}
+			]
+		},
+		"parameter-object-binding-element": {
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"begin": "(?=(([_$[:alpha:]][_$[:alnum:]]*)|(\\'[^']*\\')|(\\\"[^\"]*\\\")|(\\[([^\\[\\]]|\\[[^\\[\\]]+\\])+\\]))\\s*(:))",
+					"end": "(?=,|\\})",
+					"patterns": [
+						{
+							"include": "#object-binding-element-propertyName"
+						},
+						{
+							"include": "#parameter-binding-element"
+						}
+					]
+				},
+				{
+					"include": "#parameter-object-binding-pattern"
+				},
+				{
+					"include": "#destructuring-parameter-rest"
+				},
+				{
+					"include": "#variable-initializer"
+				},
+				{
+					"include": "#punctuation-comma"
+				}
+			]
+		},
+		"parameter-binding-element": {
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#parameter-object-binding-pattern"
+				},
+				{
+					"include": "#parameter-array-binding-pattern"
+				},
+				{
+					"include": "#destructuring-parameter-rest"
+				},
+				{
+					"include": "#variable-initializer"
+				}
+			]
+		},
+		"destructuring-parameter-rest": {
+			"match": "(?:(\\.\\.\\.)\\s*)?([_$[:alpha:]][_$[:alnum:]]*)",
+			"captures": {
+				"1": {
+					"name": "keyword.operator.rest.js"
+				},
+				"2": {
+					"name": "variable.parameter.js"
+				}
+			}
+		},
+		"parameter-object-binding-pattern": {
+			"begin": "(?:(\\.\\.\\.)\\s*)?(\\{)",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.operator.rest.js"
+				},
+				"2": {
+					"name": "punctuation.definition.binding-pattern.object.js"
+				}
+			},
+			"end": "\\}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.binding-pattern.object.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#parameter-object-binding-element"
+				}
+			]
+		},
+		"parameter-array-binding-pattern": {
+			"begin": "(?:(\\.\\.\\.)\\s*)?(\\[)",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.operator.rest.js"
+				},
+				"2": {
+					"name": "punctuation.definition.binding-pattern.array.js"
+				}
+			},
+			"end": "\\]",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.binding-pattern.array.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#parameter-binding-element"
+				},
+				{
+					"include": "#punctuation-comma"
+				}
+			]
+		},
+		"return-type": {
+			"name": "meta.return.type.js",
+			"begin": "(?<=\\))\\s*(:)",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.operator.type.annotation.js"
+				}
+			},
+			"end": "(?<!:)((?=$)|(?=\\{|;|//|\\}))",
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"name": "meta.object.type.js",
+					"begin": "(?<=:)\\s*(\\{)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.block.js"
+						}
+					},
+					"end": "\\}",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.block.js"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#type-object-members"
+						}
+					]
+				},
+				{
+					"include": "#type-predicate-operator"
+				},
+				{
+					"include": "#type"
+				}
+			]
+		},
+		"type-predicate-operator": {
+			"name": "keyword.operator.expression.is.js",
+			"match": "(?<!\\.|\\$)\\bis\\b(?!\\$)"
+		},
+		"type-annotation": {
+			"name": "meta.type.annotation.js",
+			"begin": ":",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.type.annotation.js"
+				}
+			},
+			"end": "(?=$|[,);\\}\\]]|//)|(?==[^>])|(?<=[\\}>\\]\\)]|[_$[:alpha:]])\\s*(?=\\{)",
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#type"
+				}
+			]
+		},
+		"type": {
+			"name": "meta.type.js",
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#string"
+				},
+				{
+					"include": "#numeric-literal"
+				},
+				{
+					"include": "#type-primitive"
+				},
+				{
+					"include": "#type-builtin-literals"
+				},
+				{
+					"include": "#type-parameters"
+				},
+				{
+					"include": "#type-tuple"
+				},
+				{
+					"include": "#type-object"
+				},
+				{
+					"include": "#type-operators"
+				},
+				{
+					"include": "#type-fn-type-parameters"
+				},
+				{
+					"include": "#type-paren-or-function-parameters"
+				},
+				{
+					"include": "#type-function-return-type"
+				},
+				{
+					"include": "#type-name"
+				}
+			]
+		},
+		"function-parameters": {
+			"name": "meta.parameters.js",
+			"begin": "\\(",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.parameters.begin.js"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.parameters.end.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#decorator"
+				},
+				{
+					"include": "#destructuring-parameter"
+				},
+				{
+					"include": "#parameter-name"
+				},
+				{
+					"include": "#type-annotation"
+				},
+				{
+					"include": "#variable-initializer"
+				},
+				{
+					"name": "punctuation.separator.parameter.js",
+					"match": ","
+				}
+			]
+		},
+		"type-primitive": {
+			"name": "support.type.primitive.js",
+			"match": "(?<!\\.|\\$)\\b(string|number|boolean|symbol|any|void|never)\\b(?!\\$)"
+		},
+		"type-builtin-literals": {
+			"name": "support.type.builtin.js",
+			"match": "(?<!\\.|\\$)\\b(this|true|false|undefined|null)\\b(?!\\$)"
+		},
+		"type-paren-or-function-parameters": {
+			"name": "meta.type.paren.cover.js",
+			"begin": "\\(",
+			"beginCaptures": {
+				"0": {
+					"name": "meta.brace.round.js"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "meta.brace.round.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#type"
+				},
+				{
+					"include": "#function-parameters"
+				}
+			]
+		},
+		"type-fn-type-parameters": {
+			"patterns": [
+				{
+					"name": "meta.type.constructor.js",
+					"match": "(?<!\\.|\\$)\\b(new)\\b(?=\\s*\\<)",
+					"captures": {
+						"1": {
+							"name": "keyword.control.new.js"
+						}
+					}
+				},
+				{
+					"name": "meta.type.constructor.js",
+					"begin": "(?<!\\.|\\$)\\b(new)\\b\\s*(?=\\()",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.control.new.js"
+						}
+					},
+					"end": "(?<=\\))",
+					"patterns": [
+						{
+							"include": "#function-parameters"
+						}
+					]
+				},
+				{
+					"name": "meta.type.function.js",
+					"begin": "(?<=\\>)\\s*(?=\\()",
+					"end": "(?<=\\))",
+					"patterns": [
+						{
+							"include": "#function-parameters"
+						}
+					]
+				},
+				{
+					"name": "meta.type.function.js",
+					"begin": "(?x)( (?= [(]\\s*( ([)]) |  (\\.\\.\\.) | ([_$[:alnum:]]+\\s*( ([:,?=])| ([)]\\s*=>) )) ) ) )",
+					"end": "(?<=\\))",
+					"patterns": [
+						{
+							"include": "#function-parameters"
+						}
+					]
+				}
+			]
+		},
+		"type-operators": {
+			"patterns": [
+				{
+					"include": "#typeof-operator"
+				},
+				{
+					"name": "keyword.operator.type.js",
+					"match": "[&|]"
+				},
+				{
+					"name": "keyword.operator.expression.keyof.js",
+					"match": "(?<!\\.|\\$)\\bkeyof\\b(?!\\$)"
+				}
+			]
+		},
+		"type-function-return-type": {
+			"name": "meta.type.function.return.js",
+			"begin": "=>",
+			"beginCaptures": {
+				"0": {
+					"name": "storage.type.function.arrow.js"
+				}
+			},
+			"end": "(?<!=>)(?=[,\\]\\)\\{\\}=;>]|//|$)",
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"name": "meta.object.type.js",
+					"begin": "(?<==>)\\s*(\\{)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.block.js"
+						}
+					},
+					"end": "\\}",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.block.js"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#type-object-members"
+						}
+					]
+				},
+				{
+					"include": "#type-predicate-operator"
+				},
+				{
+					"include": "#type"
+				}
+			]
+		},
+		"type-tuple": {
+			"name": "meta.type.tuple.js",
+			"begin": "\\[",
+			"beginCaptures": {
+				"0": {
+					"name": "meta.brace.square.js"
+				}
+			},
+			"end": "\\]",
+			"endCaptures": {
+				"0": {
+					"name": "meta.brace.square.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#type"
+				},
+				{
+					"include": "#punctuation-comma"
+				}
+			]
+		},
+		"type-name": {
+			"patterns": [
+				{
+					"match": "([_$[:alpha:]][_$[:alnum:]]*)\\s*(\\.)",
+					"captures": {
+						"1": {
+							"name": "entity.name.type.module.js"
+						},
+						"2": {
+							"name": "punctuation.accessor.js"
+						}
+					}
+				},
+				{
+					"name": "entity.name.type.js",
+					"match": "[_$[:alpha:]][_$[:alnum:]]*"
+				}
+			]
+		},
+		"type-parameters": {
+			"name": "meta.type.parameters.js",
+			"begin": "(<)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.typeparameters.begin.js"
+				}
+			},
+			"end": "(?=$)|(>)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.typeparameters.end.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"name": "storage.modifier.js",
+					"match": "(?<!\\.|\\$)\\b(extends)\\b(?!\\$)"
+				},
+				{
+					"include": "#type"
+				},
+				{
+					"include": "#punctuation-comma"
+				}
+			]
+		},
+		"variable-initializer": {
+			"begin": "(?<!=|!)(=)(?!=)",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.operator.assignment.js"
+				}
+			},
+			"end": "(?=$|[,);}\\]])",
+			"patterns": [
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"for-loop": {
+			"begin": "(?<!\\.|\\$)\\b(for)\\s*(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.loop.js"
+				},
+				"2": {
+					"name": "meta.brace.round.js"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "meta.brace.round.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#var-expr"
+				},
+				{
+					"include": "#expression"
+				},
+				{
+					"include": "#punctuation-semicolon"
+				}
+			]
+		},
+		"switch-expression": {
+			"name": "switch-expression.expr.js",
+			"begin": "(?<!\\.|\\$)\\b(switch)\\s*(\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.switch.js"
+				},
+				"2": {
+					"name": "meta.brace.round.js"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "meta.brace.round.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"switch-block": {
+			"name": "switch-block.expr.js",
+			"begin": "{",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.block.js"
+				}
+			},
+			"end": "(?=\\})",
+			"patterns": [
+				{
+					"include": "#case-clause"
+				},
+				{
+					"include": "#statements"
+				}
+			]
+		},
+		"case-clause": {
+			"name": "case-clause.expr.js",
+			"begin": "(?<!\\.|\\$)\\b(case|default(?=:))\\b(?!\\$)",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.control.switch.js"
+				}
+			},
+			"end": ":",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.section.case-statement.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"switch-statement": {
+			"name": "switch-statement.expr.js",
+			"begin": "(?<!\\.|\\$)(?=\\bswitch\\s*\\()",
+			"end": "}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.block.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#switch-expression"
+				},
+				{
+					"include": "#switch-block"
+				}
+			]
+		},
+		"support-objects": {
+			"patterns": [
+				{
+					"name": "variable.language.arguments.js",
+					"match": "(?<!\\.|\\$)\\b(arguments)\\b(?!\\$)"
+				},
+				{
+					"name": "support.class.builtin.js",
+					"match": "(?x)(?<!\\.|\\$)\\b(Array|ArrayBuffer|Atomics|Boolean|DataView|Date|Float32Array|Float64Array|Function|Generator |GeneratorFunction|Int8Array|Int16Array|Int32Array|Intl|Map|Number|Object|Promise|Proxy |Reflect|RegExp|Set|SharedArrayBuffer|SIMD|String|Symbol|TypedArray |Uint8Array|Uint16Array|Uint32Array|Uint8ClampedArray|WeakMap|WeakSet)\\b(?!\\$)"
+				},
+				{
+					"name": "support.class.error.js",
+					"match": "(?<!\\.|\\$)\\b((Eval|Internal|Range|Reference|Syntax|Type|URI)?Error)\\b(?!\\$)"
+				},
+				{
+					"name": "support.function.js",
+					"match": "(?x)(?<!\\.|\\$)\\b(clear(Interval|Timeout)|decodeURI|decodeURIComponent|encodeURI|encodeURIComponent|escape|eval| isFinite|isNaN|parseFloat|parseInt|require|set(Interval|Timeout)|super|unescape|uneval)(?=\\s*\\()"
+				},
+				{
+					"match": "(?x)(?<!\\.|\\$)\\b(Math)(?:\\s*(\\.)\\s*(?:\n  (abs|acos|acosh|asin|asinh|atan|atan2|atanh|cbrt|ceil|clz32|cos|cosh|exp|\n  expm1|floor|fround|hypot|imul|log|log10|log1p|log2|max|min|pow|random|\n  round|sign|sin|sinh|sqrt|tan|tanh|trunc)\n  |\n  (E|LN10|LN2|LOG10E|LOG2E|PI|SQRT1_2|SQRT2)))?\\b(?!\\$)",
+					"captures": {
+						"1": {
+							"name": "support.constant.math.js"
+						},
+						"2": {
+							"name": "punctuation.accessor.js"
+						},
+						"3": {
+							"name": "support.function.math.js"
+						},
+						"4": {
+							"name": "support.constant.property.math.js"
+						}
+					}
+				},
+				{
+					"match": "(?x)(?<!\\.|\\$)\\b(console)(?:\\s*(\\.)\\s*(\n  assert|clear|count|debug|dir|error|group|groupCollapsed|groupEnd|info|log\n  |profile|profileEnd|table|time|timeEnd|timeStamp|trace|warn))?\\b(?!\\$)",
+					"captures": {
+						"1": {
+							"name": "support.class.console.js"
+						},
+						"2": {
+							"name": "punctuation.accessor.js"
+						},
+						"3": {
+							"name": "support.function.console.js"
+						}
+					}
+				},
+				{
+					"match": "(?<!\\.|\\$)\\b(JSON)(?:\\s*(\\.)\\s*(parse|stringify))?\\b(?!\\$)",
+					"captures": {
+						"1": {
+							"name": "support.constant.json.js"
+						},
+						"2": {
+							"name": "punctuation.accessor.js"
+						},
+						"3": {
+							"name": "support.function.json.js"
+						}
+					}
+				},
+				{
+					"match": "(?x) (\\.) \\s* (?:\n  (constructor|length|prototype|__proto__) \n  |\n  (EPSILON|MAX_SAFE_INTEGER|MAX_VALUE|MIN_SAFE_INTEGER|MIN_VALUE|NEGATIVE_INFINITY|POSITIVE_INFINITY))\\b(?!\\$)",
+					"captures": {
+						"1": {
+							"name": "punctuation.accessor.js"
+						},
+						"2": {
+							"name": "support.variable.property.js"
+						},
+						"3": {
+							"name": "support.constant.js"
+						}
+					}
+				},
+				{
+					"match": "(?x) (?<!\\.|\\$) \\b (?:\n  (document|event|navigator|performance|screen|window) \n  |\n  (AnalyserNode|ArrayBufferView|Attr|AudioBuffer|AudioBufferSourceNode|AudioContext|AudioDestinationNode|AudioListener\n  |AudioNode|AudioParam|BatteryManager|BeforeUnloadEvent|BiquadFilterNode|Blob|BufferSource|ByteString|CSS|CSSConditionRule\n  |CSSCounterStyleRule|CSSGroupingRule|CSSMatrix|CSSMediaRule|CSSPageRule|CSSPrimitiveValue|CSSRule|CSSRuleList|CSSStyleDeclaration\n  |CSSStyleRule|CSSStyleSheet|CSSSupportsRule|CSSValue|CSSValueList|CanvasGradient|CanvasImageSource|CanvasPattern\n  |CanvasRenderingContext2D|ChannelMergerNode|ChannelSplitterNode|CharacterData|ChromeWorker|CloseEvent|Comment|CompositionEvent\n  |Console|ConvolverNode|Coordinates|Credential|CredentialsContainer|Crypto|CryptoKey|CustomEvent|DOMError|DOMException\n  |DOMHighResTimeStamp|DOMImplementation|DOMString|DOMStringList|DOMStringMap|DOMTimeStamp|DOMTokenList|DataTransfer\n  |DataTransferItem|DataTransferItemList|DedicatedWorkerGlobalScope|DelayNode|DeviceProximityEvent|DirectoryEntry\n  |DirectoryEntrySync|DirectoryReader|DirectoryReaderSync|Document|DocumentFragment|DocumentTouch|DocumentType|DragEvent\n  |DynamicsCompressorNode|Element|Entry|EntrySync|ErrorEvent|Event|EventListener|EventSource|EventTarget|FederatedCredential\n  |FetchEvent|File|FileEntry|FileEntrySync|FileException|FileList|FileReader|FileReaderSync|FileSystem|FileSystemSync\n  |FontFace|FormData|GainNode|Gamepad|GamepadButton|GamepadEvent|Geolocation|GlobalEventHandlers|HTMLAnchorElement\n  |HTMLAreaElement|HTMLAudioElement|HTMLBRElement|HTMLBaseElement|HTMLBodyElement|HTMLButtonElement|HTMLCanvasElement\n  |HTMLCollection|HTMLContentElement|HTMLDListElement|HTMLDataElement|HTMLDataListElement|HTMLDialogElement|HTMLDivElement\n  |HTMLDocument|HTMLElement|HTMLEmbedElement|HTMLFieldSetElement|HTMLFontElement|HTMLFormControlsCollection|HTMLFormElement\n  |HTMLHRElement|HTMLHeadElement|HTMLHeadingElement|HTMLHtmlElement|HTMLIFrameElement|HTMLImageElement|HTMLInputElement\n  |HTMLKeygenElement|HTMLLIElement|HTMLLabelElement|HTMLLegendElement|HTMLLinkElement|HTMLMapElement|HTMLMediaElement\n  |HTMLMetaElement|HTMLMeterElement|HTMLModElement|HTMLOListElement|HTMLObjectElement|HTMLOptGroupElement|HTMLOptionElement\n  |HTMLOptionsCollection|HTMLOutputElement|HTMLParagraphElement|HTMLParamElement|HTMLPreElement|HTMLProgressElement\n  |HTMLQuoteElement|HTMLScriptElement|HTMLSelectElement|HTMLShadowElement|HTMLSourceElement|HTMLSpanElement|HTMLStyleElement\n  |HTMLTableCaptionElement|HTMLTableCellElement|HTMLTableColElement|HTMLTableDataCellElement|HTMLTableElement|HTMLTableHeaderCellElement\n  |HTMLTableRowElement|HTMLTableSectionElement|HTMLTextAreaElement|HTMLTimeElement|HTMLTitleElement|HTMLTrackElement\n  |HTMLUListElement|HTMLUnknownElement|HTMLVideoElement|HashChangeEvent|History|IDBCursor|IDBCursorWithValue|IDBDatabase\n  |IDBEnvironment|IDBFactory|IDBIndex|IDBKeyRange|IDBMutableFile|IDBObjectStore|IDBOpenDBRequest|IDBRequest|IDBTransaction\n  |IDBVersionChangeEvent|IIRFilterNode|IdentityManager|ImageBitmap|ImageBitmapFactories|ImageData|Index|InputDeviceCapabilities\n  |InputEvent|InstallEvent|InstallTrigger|KeyboardEvent|LinkStyle|LocalFileSystem|LocalFileSystemSync|Location|MIDIAccess\n  |MIDIConnectionEvent|MIDIInput|MIDIInputMap|MIDIOutputMap|MediaElementAudioSourceNode|MediaError|MediaKeyMessageEvent\n  |MediaKeySession|MediaKeyStatusMap|MediaKeySystemAccess|MediaKeySystemConfiguration|MediaKeys|MediaRecorder|MediaStream\n  |MediaStreamAudioDestinationNode|MediaStreamAudioSourceNode|MessageChannel|MessageEvent|MessagePort|MouseEvent\n  |MutationObserver|MutationRecord|NamedNodeMap|Navigator|NavigatorConcurrentHardware|NavigatorGeolocation|NavigatorID\n  |NavigatorLanguage|NavigatorOnLine|Node|NodeFilter|NodeIterator|NodeList|NonDocumentTypeChildNode|Notification\n  |OfflineAudioCompletionEvent|OfflineAudioContext|OscillatorNode|PageTransitionEvent|PannerNode|ParentNode|PasswordCredential\n  |Path2D|PaymentAddress|PaymentRequest|PaymentResponse|Performance|PerformanceEntry|PerformanceFrameTiming|PerformanceMark\n  |PerformanceMeasure|PerformanceNavigation|PerformanceNavigationTiming|PerformanceObserver|PerformanceObserverEntryList\n  |PerformanceResourceTiming|PerformanceTiming|PeriodicSyncEvent|PeriodicWave|Plugin|Point|PointerEvent|PopStateEvent\n  |PortCollection|Position|PositionError|PositionOptions|PresentationConnectionClosedEvent|PresentationConnectionList\n  |PresentationReceiver|ProcessingInstruction|ProgressEvent|PromiseRejectionEvent|PushEvent|PushRegistrationManager\n  |RTCCertificate|RTCConfiguration|RTCPeerConnection|RTCSessionDescriptionCallback|RTCStatsReport|RadioNodeList|RandomSource\n  |Range|ReadableByteStream|RenderingContext|SVGAElement|SVGAngle|SVGAnimateColorElement|SVGAnimateElement|SVGAnimateMotionElement\n  |SVGAnimateTransformElement|SVGAnimatedAngle|SVGAnimatedBoolean|SVGAnimatedEnumeration|SVGAnimatedInteger|SVGAnimatedLength\n  |SVGAnimatedLengthList|SVGAnimatedNumber|SVGAnimatedNumberList|SVGAnimatedPoints|SVGAnimatedPreserveAspectRatio\n  |SVGAnimatedRect|SVGAnimatedString|SVGAnimatedTransformList|SVGAnimationElement|SVGCircleElement|SVGClipPathElement\n  |SVGCursorElement|SVGDefsElement|SVGDescElement|SVGElement|SVGEllipseElement|SVGEvent|SVGFilterElement|SVGFontElement\n  |SVGFontFaceElement|SVGFontFaceFormatElement|SVGFontFaceNameElement|SVGFontFaceSrcElement|SVGFontFaceUriElement\n  |SVGForeignObjectElement|SVGGElement|SVGGlyphElement|SVGGradientElement|SVGHKernElement|SVGImageElement|SVGLength\n  |SVGLengthList|SVGLineElement|SVGLinearGradientElement|SVGMPathElement|SVGMaskElement|SVGMatrix|SVGMissingGlyphElement\n  |SVGNumber|SVGNumberList|SVGPathElement|SVGPatternElement|SVGPoint|SVGPolygonElement|SVGPolylineElement|SVGPreserveAspectRatio\n  |SVGRadialGradientElement|SVGRect|SVGRectElement|SVGSVGElement|SVGScriptElement|SVGSetElement|SVGStopElement|SVGStringList\n  |SVGStylable|SVGStyleElement|SVGSwitchElement|SVGSymbolElement|SVGTRefElement|SVGTSpanElement|SVGTests|SVGTextElement\n  |SVGTextPositioningElement|SVGTitleElement|SVGTransform|SVGTransformList|SVGTransformable|SVGUseElement|SVGVKernElement\n  |SVGViewElement|ServiceWorker|ServiceWorkerContainer|ServiceWorkerGlobalScope|ServiceWorkerRegistration|ServiceWorkerState\n  |ShadowRoot|SharedWorker|SharedWorkerGlobalScope|SourceBufferList|StereoPannerNode|Storage|StorageEvent|StyleSheet\n  |StyleSheetList|SubtleCrypto|SyncEvent|Text|TextMetrics|TimeEvent|TimeRanges|Touch|TouchEvent|TouchList|Transferable\n  |TreeWalker|UIEvent|USVString|VRDisplayCapabilities|ValidityState|WaveShaperNode|WebGL|WebGLActiveInfo|WebGLBuffer\n  |WebGLContextEvent|WebGLFramebuffer|WebGLProgram|WebGLRenderbuffer|WebGLRenderingContext|WebGLShader|WebGLShaderPrecisionFormat\n  |WebGLTexture|WebGLTimerQueryEXT|WebGLTransformFeedback|WebGLUniformLocation|WebGLVertexArrayObject|WebGLVertexArrayObjectOES\n  |WebSocket|WebSockets|WebVTT|WheelEvent|Window|WindowBase64|WindowEventHandlers|WindowTimers|Worker|WorkerGlobalScope\n  |WorkerLocation|WorkerNavigator|XMLHttpRequest|XMLHttpRequestEventTarget|XMLSerializer|XPathExpression|XPathResult\n  |XSLTProcessor))\\b(?!\\$)",
+					"captures": {
+						"1": {
+							"name": "support.variable.dom.js"
+						},
+						"2": {
+							"name": "support.class.dom.js"
+						}
+					}
+				},
+				{
+					"match": "(?x) (\\.) \\s* (?:\n  (ATTRIBUTE_NODE|CDATA_SECTION_NODE|COMMENT_NODE|DOCUMENT_FRAGMENT_NODE|DOCUMENT_NODE|DOCUMENT_TYPE_NODE\n  |DOMSTRING_SIZE_ERR|ELEMENT_NODE|ENTITY_NODE|ENTITY_REFERENCE_NODE|HIERARCHY_REQUEST_ERR|INDEX_SIZE_ERR\n  |INUSE_ATTRIBUTE_ERR|INVALID_CHARACTER_ERR|NO_DATA_ALLOWED_ERR|NO_MODIFICATION_ALLOWED_ERR|NOT_FOUND_ERR\n  |NOT_SUPPORTED_ERR|NOTATION_NODE|PROCESSING_INSTRUCTION_NODE|TEXT_NODE|WRONG_DOCUMENT_ERR)\n  |\n  (_content|[xyz]|abbr|above|accept|acceptCharset|accessKey|action|align|[av]Link(?:color)?|all|alt|anchors|appCodeName\n  |appCore|applets|appMinorVersion|appName|appVersion|archive|areas|arguments|attributes|availHeight|availLeft|availTop\n  |availWidth|axis|background|backgroundColor|backgroundImage|below|bgColor|body|border|borderBottomWidth|borderColor\n  |borderLeftWidth|borderRightWidth|borderStyle|borderTopWidth|borderWidth|bottom|bufferDepth|callee|caller|caption\n  |cellPadding|cells|cellSpacing|ch|characterSet|charset|checked|childNodes|chOff|cite|classes|className|clear\n  |clientInformation|clip|clipBoardData|closed|code|codeBase|codeType|color|colorDepth|cols|colSpan|compact|complete\n  |components|content|controllers|cookie|cookieEnabled|cords|cpuClass|crypto|current|data|dateTime|declare|defaultCharset\n  |defaultChecked|defaultSelected|defaultStatus|defaultValue|defaultView|defer|description|dialogArguments|dialogHeight\n  |dialogLeft|dialogTop|dialogWidth|dir|directories|disabled|display|docmain|doctype|documentElement|elements|embeds\n  |enabledPlugin|encoding|enctype|entities|event|expando|external|face|fgColor|filename|firstChild|fontFamily|fontSize\n  |fontWeight|form|formName|forms|frame|frameBorder|frameElement|frames|hasFocus|hash|headers|height|history|host\n  |hostname|href|hreflang|hspace|htmlFor|httpEquiv|id|ids|ignoreCase|images|implementation|index|innerHeight|innerWidth\n  |input|isMap|label|lang|language|lastChild|lastIndex|lastMatch|lastModified|lastParen|layer[sXY]|left|leftContext\n  |lineHeight|link|linkColor|links|listStyleType|localName|location|locationbar|longDesc|lowsrc|lowSrc|marginBottom\n  |marginHeight|marginLeft|marginRight|marginTop|marginWidth|maxLength|media|menubar|method|mimeTypes|multiline|multiple\n  |name|nameProp|namespaces|namespaceURI|next|nextSibling|nodeName|nodeType|nodeValue|noHref|noResize|noShade|notationName\n  |notations|noWrap|object|offscreenBuffering|onLine|onreadystatechange|opener|opsProfile|options|oscpu|outerHeight\n  |outerWidth|ownerDocument|paddingBottom|paddingLeft|paddingRight|paddingTop|page[XY]|page[XY]Offset|parent|parentLayer\n  |parentNode|parentWindow|pathname|personalbar|pixelDepth|pkcs11|platform|plugins|port|prefix|previous|previousDibling\n  |product|productSub|profile|profileend|prompt|prompter|protocol|publicId|readOnly|readyState|referrer|rel|responseText\n  |responseXML|rev|right|rightContext|rowIndex|rows|rowSpan|rules|scheme|scope|screen[XY]|screenLeft|screenTop|scripts\n  |scrollbars|scrolling|sectionRowIndex|security|securityPolicy|selected|selectedIndex|selection|self|shape|siblingAbove\n  |siblingBelow|size|source|specified|standby|start|status|statusbar|statusText|style|styleSheets|suffixes|summary\n  |systemId|systemLanguage|tagName|tags|target|tBodies|text|textAlign|textDecoration|textIndent|textTransform|tFoot|tHead\n  |title|toolbar|top|type|undefined|uniqueID|updateInterval|URL|URLUnencoded|useMap|userAgent|userLanguage|userProfile\n  |vAlign|value|valueType|vendor|vendorSub|version|visibility|vspace|whiteSpace|width|X[MS]LDocument|zIndex))\\b(?!\\$|\\s*(<([^<>]|\\<[^<>]+\\>)+>\\s*)?\\()",
+					"captures": {
+						"1": {
+							"name": "punctuation.accessor.js"
+						},
+						"2": {
+							"name": "support.constant.dom.js"
+						},
+						"3": {
+							"name": "support.variable.property.dom.js"
+						}
+					}
+				},
+				{
+					"name": "support.class.node.js",
+					"match": "(?x)(?<!\\.|\\$)\\b(Buffer|EventEmitter|Server|Pipe|Socket|REPLServer|ReadStream|WriteStream|Stream\n  |Inflate|Deflate|InflateRaw|DeflateRaw|GZip|GUnzip|Unzip|Zip)\\b(?!\\$)"
+				},
+				{
+					"name": "support.module.node.js",
+					"match": "(?x)(?<!\\.|\\$)\\b(assert|buffer|child_process|cluster|constants|crypto|dgram|dns|domain|events|fs|http|https|net\n  |os|path|punycode|querystring|readline|repl|stream|string_decoder|timers|tls|tty|url|util|vm|zlib)\\b(?!\\$)"
+				},
+				{
+					"match": "(?x)(?<!\\.|\\$)\\b(process)(?:(\\.)(?:\n  (arch|argv|config|connected|env|execArgv|execPath|exitCode|mainModule|pid|platform|release|stderr|stdin|stdout|title|version|versions)\n  |\n  (abort|chdir|cwd|disconnect|exit|[sg]ete?[gu]id|send|[sg]etgroups|initgroups|kill|memoryUsage|nextTick|umask|uptime|hrtime)\n))?\\b(?!\\$)",
+					"captures": {
+						"1": {
+							"name": "support.variable.object.process.js"
+						},
+						"2": {
+							"name": "punctuation.accessor.js"
+						},
+						"3": {
+							"name": "support.variable.property.process.js"
+						},
+						"4": {
+							"name": "support.function.process.js"
+						}
+					}
+				},
+				{
+					"match": "(?<!\\.|\\$)\\b(?:(exports)|(module)(?:(\\.)(exports|id|filename|loaded|parent|children))?)\\b(?!\\$)",
+					"captures": {
+						"1": {
+							"name": "support.type.object.module.js"
+						},
+						"2": {
+							"name": "support.type.object.module.js"
+						},
+						"3": {
+							"name": "punctuation.accessor.js"
+						},
+						"4": {
+							"name": "support.type.object.module.js"
+						}
+					}
+				},
+				{
+					"name": "support.variable.object.node.js",
+					"match": "(?<!\\.|\\$)\\b(global|GLOBAL|root|__dirname|__filename)\\b(?!\\$)"
+				},
+				{
+					"match": "(?x) (\\.) \\s* \n(?:\n (on(?:Rowsinserted|Rowsdelete|Rowenter|Rowexit|Resize|Resizestart|Resizeend|Reset|\n   Readystatechange|Mouseout|Mouseover|Mousedown|Mouseup|Mousemove|\n   Before(?:cut|deactivate|unload|update|paste|print|editfocus|activate)|\n   Blur|Scrolltop|Submit|Select|Selectstart|Selectionchange|Hover|Help|\n   Change|Contextmenu|Controlselect|Cut|Cellchange|Clock|Close|Deactivate|\n   Datasetchanged|Datasetcomplete|Dataavailable|Drop|Drag|Dragstart|Dragover|\n   Dragdrop|Dragenter|Dragend|Dragleave|Dblclick|Unload|Paste|Propertychange|Error|\n   Errorupdate|Keydown|Keyup|Keypress|Focus|Load|Activate|Afterupdate|Afterprint|Abort)\n ) |\n (shift|showModelessDialog|showModalDialog|showHelp|scroll|scrollX|scrollByPages|\n   scrollByLines|scrollY|scrollTo|stop|strike|sizeToContent|sidebar|signText|sort|\n   sup|sub|substr|substring|splice|split|send|set(?:Milliseconds|Seconds|Minutes|Hours|\n   Month|Year|FullYear|Date|UTC(?:Milliseconds|Seconds|Minutes|Hours|Month|FullYear|Date)|\n   Time|Hotkeys|Cursor|ZOptions|Active|Resizable|RequestHeader)|search|slice|\n   savePreferences|small|home|handleEvent|navigate|char|charCodeAt|charAt|concat|\n   contextual|confirm|compile|clear|captureEvents|call|createStyleSheet|createPopup|\n   createEventObject|to(?:GMTString|UTCString|String|Source|UpperCase|LowerCase|LocaleString)|\n   test|taint|taintEnabled|indexOf|italics|disableExternalCapture|dump|detachEvent|unshift|\n   untaint|unwatch|updateCommands|join|javaEnabled|pop|push|plugins.refresh|paddings|parse|\n   print|prompt|preference|enableExternalCapture|exec|execScript|valueOf|UTC|find|file|\n   fileModifiedDate|fileSize|fileCreatedDate|fileUpdatedDate|fixed|fontsize|fontcolor|\n   forward|fromCharCode|watch|link|load|lastIndexOf|anchor|attachEvent|atob|apply|alert|\n   abort|routeEvents|resize|resizeBy|resizeTo|recalc|returnValue|replace|reverse|reload|\n   releaseCapture|releaseEvents|go|get(?:Milliseconds|Seconds|Minutes|Hours|Month|Day|Year|FullYear|\n   Time|Date|TimezoneOffset|UTC(?:Milliseconds|Seconds|Minutes|Hours|Day|Month|FullYear|Date)|\n   Attention|Selection|ResponseHeader|AllResponseHeaders)|moveBy|moveBelow|moveTo|\n   moveToAbsolute|moveAbove|mergeAttributes|match|margins|btoa|big|bold|borderWidths|blink|back\n ) |\n (acceptNode|add|addEventListener|addTextTrack|adoptNode|after|animate|append|\n   appendChild|appendData|before|blur|canPlayType|captureStream|\n   caretPositionFromPoint|caretRangeFromPoint|checkValidity|clear|click|\n   cloneContents|cloneNode|cloneRange|close|closest|collapse|\n   compareBoundaryPoints|compareDocumentPosition|comparePoint|contains|\n   convertPointFromNode|convertQuadFromNode|convertRectFromNode|createAttribute|\n   createAttributeNS|createCaption|createCDATASection|createComment|\n   createContextualFragment|createDocument|createDocumentFragment|\n   createDocumentType|createElement|createElementNS|createEntityReference|\n   createEvent|createExpression|createHTMLDocument|createNodeIterator|\n   createNSResolver|createProcessingInstruction|createRange|createShadowRoot|\n   createTBody|createTextNode|createTFoot|createTHead|createTreeWalker|delete|\n   deleteCaption|deleteCell|deleteContents|deleteData|deleteRow|deleteTFoot|\n   deleteTHead|detach|disconnect|dispatchEvent|elementFromPoint|elementsFromPoint|\n   enableStyleSheetsForSet|entries|evaluate|execCommand|exitFullscreen|\n   exitPointerLock|expand|extractContents|fastSeek|firstChild|focus|forEach|get|\n   getAll|getAnimations|getAttribute|getAttributeNames|getAttributeNode|\n   getAttributeNodeNS|getAttributeNS|getBoundingClientRect|getBoxQuads|\n   getClientRects|getContext|getDestinationInsertionPoints|getElementById|\n   getElementsByClassName|getElementsByName|getElementsByTagName|\n   getElementsByTagNameNS|getItem|getNamedItem|getSelection|getStartDate|\n   getVideoPlaybackQuality|has|hasAttribute|hasAttributeNS|hasAttributes|\n   hasChildNodes|hasFeature|hasFocus|importNode|initEvent|insertAdjacentElement|\n   insertAdjacentHTML|insertAdjacentText|insertBefore|insertCell|insertData|\n   insertNode|insertRow|intersectsNode|isDefaultNamespace|isEqualNode|\n   isPointInRange|isSameNode|item|key|keys|lastChild|load|lookupNamespaceURI|\n   lookupPrefix|matches|move|moveAttribute|moveAttributeNode|moveChild|\n   moveNamedItem|namedItem|nextNode|nextSibling|normalize|observe|open|\n   parentNode|pause|play|postMessage|prepend|preventDefault|previousNode|\n   previousSibling|probablySupportsContext|queryCommandEnabled|\n   queryCommandIndeterm|queryCommandState|queryCommandSupported|queryCommandValue|\n   querySelector|querySelectorAll|registerContentHandler|registerElement|\n   registerProtocolHandler|releaseCapture|releaseEvents|remove|removeAttribute|\n   removeAttributeNode|removeAttributeNS|removeChild|removeEventListener|\n   removeItem|replace|replaceChild|replaceData|replaceWith|reportValidity|\n   requestFullscreen|requestPointerLock|reset|scroll|scrollBy|scrollIntoView|\n   scrollTo|seekToNextFrame|select|selectNode|selectNodeContents|set|setAttribute|\n   setAttributeNode|setAttributeNodeNS|setAttributeNS|setCapture|\n   setCustomValidity|setEnd|setEndAfter|setEndBefore|setItem|setNamedItem|\n   setRangeText|setSelectionRange|setSinkId|setStart|setStartAfter|setStartBefore|\n   slice|splitText|stepDown|stepUp|stopImmediatePropagation|stopPropagation|\n   submit|substringData|supports|surroundContents|takeRecords|terminate|toBlob|\n   toDataURL|toggle|toString|values|write|writeln\n )\n)(?=\\s*\\()",
+					"captures": {
+						"1": {
+							"name": "punctuation.accessor.js"
+						},
+						"2": {
+							"name": "support.function.event-handler.js"
+						},
+						"3": {
+							"name": "support.function.js"
+						},
+						"4": {
+							"name": "support.function.dom.js"
+						}
+					}
+				}
+			]
+		},
+		"function-call": {
+			"begin": "(?=(\\.\\s*)?([_$[:alpha:]][_$[:alnum:]]*)\\s*(<([^<>]|\\<[^<>]+\\>)+>\\s*)?\\()",
+			"end": "(?<=\\))(?!(\\.\\s*)?([_$[:alpha:]][_$[:alnum:]]*)\\s*(<([^<>]|\\<[^<>]+\\>)+>\\s*)?\\()",
+			"patterns": [
+				{
+					"include": "#support-objects"
+				},
+				{
+					"name": "punctuation.accessor.js",
+					"match": "\\."
+				},
+				{
+					"name": "entity.name.function.js",
+					"match": "([_$[:alpha:]][_$[:alnum:]]*)"
+				},
+				{
+					"include": "#comment"
+				},
+				{
+					"name": "meta.type.parameters.js",
+					"begin": "\\<",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.typeparameters.begin.js"
+						}
+					},
+					"end": "\\>",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.typeparameters.end.js"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#type"
+						},
+						{
+							"include": "#punctuation-comma"
+						}
+					]
+				},
+				{
+					"include": "#paren-expression"
+				}
+			]
+		},
+		"identifiers": {
+			"patterns": [
+				{
+					"name": "support.class.js",
+					"match": "([_$[:alpha:]][_$[:alnum:]]*)(?=\\s*\\.\\s*prototype\\b(?!\\$))"
+				},
+				{
+					"match": "(?x)(\\.)\\s*(?:\n  ([[:upper:]][_$[:digit:][:upper:]]*) |\n  ([_$[:alpha:]][_$[:alnum:]]*)\n)(?=\\s*\\.\\s*[_$[:alpha:]][_$[:alnum:]]*)",
+					"captures": {
+						"1": {
+							"name": "punctuation.accessor.js"
+						},
+						"2": {
+							"name": "constant.other.object.property.js"
+						},
+						"3": {
+							"name": "variable.other.object.property.js"
+						}
+					}
+				},
+				{
+					"match": "(?x)(?:(\\.)\\s*)?([_$[:alpha:]][_$[:alnum:]]*)(?=\\s*=\\s*( (async\\s+)|(function\\s*[(<])|(function\\s+)| ([_$[:alpha:]][_$[:alnum:]]*\\s*=>)| ((<([^<>]|\\<[^<>]+\\>)+>\\s*)?\\(([^()]|\\([^()]*\\))*\\)(\\s*:\\s*(.)*)?\\s*=>)))",
+					"captures": {
+						"1": {
+							"name": "punctuation.accessor.js"
+						},
+						"2": {
+							"name": "entity.name.function.js"
+						}
+					}
+				},
+				{
+					"match": "(\\.)\\s*([[:upper:]][_$[:digit:][:upper:]]*)(?![_$[:alnum:]])",
+					"captures": {
+						"1": {
+							"name": "punctuation.accessor.js"
+						},
+						"2": {
+							"name": "constant.other.property.js"
+						}
+					}
+				},
+				{
+					"match": "(\\.)\\s*([_$[:alpha:]][_$[:alnum:]]*)",
+					"captures": {
+						"1": {
+							"name": "punctuation.accessor.js"
+						},
+						"2": {
+							"name": "variable.other.property.js"
+						}
+					}
+				},
+				{
+					"match": "(?x)(?:\n  ([[:upper:]][_$[:digit:][:upper:]]*) |\n  ([_$[:alpha:]][_$[:alnum:]]*)\n)(?=\\s*\\.\\s*[_$[:alpha:]][_$[:alnum:]]*)",
+					"captures": {
+						"1": {
+							"name": "constant.other.object.js"
+						},
+						"2": {
+							"name": "variable.other.object.js"
+						}
+					}
+				},
+				{
+					"name": "constant.other.js",
+					"match": "([[:upper:]][_$[:digit:][:upper:]]*)(?![_$[:alnum:]])"
+				},
+				{
+					"name": "variable.other.readwrite.js",
+					"match": "[_$[:alpha:]][_$[:alnum:]]*"
+				}
+			]
+		},
+		"cast": {
+			"patterns": [
+				{
+					"include": "#jsx"
+				}
+			]
+		},
+		"new-expr": {
+			"name": "new.expr.js",
+			"begin": "(?<!\\.|\\$)\\b(new)\\b(?!\\$)",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.operator.new.js"
+				}
+			},
+			"end": "(?<=\\))|(?=[;),]|$|((?<!\\.|\\$)\\bnew\\b(?!\\$)))",
+			"patterns": [
+				{
+					"include": "#paren-expression"
+				},
+				{
+					"include": "#class-or-interface-declaration"
+				},
+				{
+					"include": "#type"
+				}
+			]
+		},
+		"object-member": {
+			"patterns": [
+				{
+					"include": "#comment"
+				},
+				{
+					"include": "#method-declaration"
+				},
+				{
+					"name": "meta.object.member.js",
+					"begin": "(?=(?:(?:\\'[^']*\\')|(?:\\\"[^\"]*\\\")|(?:\\[([^\\[\\]]|\\[[^\\[\\]]+\\])+\\]))\\s*:)",
+					"end": "(?=,|\\})",
+					"patterns": [
+						{
+							"name": "meta.object-literal.key.js",
+							"begin": "(?=(?:(?:\\'[^']*\\')|(?:\\\"[^\"]*\\\")|(?:\\[([^\\[\\]]|\\[[^\\[\\]]+\\])+\\]))\\s*:)",
+							"end": ":",
+							"endCaptures": {
+								"0": {
+									"name": "punctuation.separator.key-value.js"
+								}
+							},
+							"patterns": [
+								{
+									"include": "#string"
+								},
+								{
+									"include": "#array-literal"
+								}
+							]
+						},
+						{
+							"include": "#expression"
+						}
+					]
+				},
+				{
+					"name": "meta.object.member.js",
+					"begin": "(?x)(?:([_$[:alpha:]][_$[:alnum:]]*)\\s*(:)(?=\\s*( (async\\s+)|(function\\s*[(<])|(function\\s+)| ([_$[:alpha:]][_$[:alnum:]]*\\s*=>)| ((<([^<>]|\\<[^<>]+\\>)+>\\s*)?\\(([^()]|\\([^()]*\\))*\\)(\\s*:\\s*(.)*)?\\s*=>))))",
+					"beginCaptures": {
+						"0": {
+							"name": "meta.object-literal.key.js"
+						},
+						"1": {
+							"name": "entity.name.function.js"
+						},
+						"2": {
+							"name": "punctuation.separator.key-value.js"
+						}
+					},
+					"end": "(?=,|\\})",
+					"patterns": [
+						{
+							"include": "#expression"
+						}
+					]
+				},
+				{
+					"name": "meta.object.member.js",
+					"begin": "(?:[_$[:alpha:]][_$[:alnum:]]*)\\s*(:)",
+					"beginCaptures": {
+						"0": {
+							"name": "meta.object-literal.key.js"
+						},
+						"1": {
+							"name": "punctuation.separator.key-value.js"
+						}
+					},
+					"end": "(?=,|\\})",
+					"patterns": [
+						{
+							"include": "#expression"
+						}
+					]
+				},
+				{
+					"name": "meta.object.member.js",
+					"begin": "\\.\\.\\.",
+					"beginCaptures": {
+						"0": {
+							"name": "keyword.operator.spread.js"
+						}
+					},
+					"end": "(?=,|\\})",
+					"patterns": [
+						{
+							"include": "#expression"
+						}
+					]
+				},
+				{
+					"name": "meta.object.member.js",
+					"match": "([_$[:alpha:]][_$[:alnum:]]*)\\s*(?=,|\\}|$)",
+					"captures": {
+						"1": {
+							"name": "variable.other.readwrite.js"
+						}
+					}
+				},
+				{
+					"include": "#punctuation-comma"
+				}
+			]
+		},
+		"expression-operators": {
+			"patterns": [
+				{
+					"name": "keyword.control.flow.js",
+					"match": "(?<!\\.|\\$)\\b(await)\\b(?!\\$)"
+				},
+				{
+					"name": "keyword.operator.expression.delete.js",
+					"match": "(?<!\\.|\\$)\\bdelete\\b(?!\\$)"
+				},
+				{
+					"name": "keyword.operator.expression.in.js",
+					"match": "(?<!\\.|\\$)\\bin\\b(?!\\$)"
+				},
+				{
+					"name": "keyword.operator.expression.of.js",
+					"match": "(?<!\\.|\\$)\\bof\\b(?!\\$)"
+				},
+				{
+					"name": "keyword.operator.expression.instanceof.js",
+					"match": "(?<!\\.|\\$)\\binstanceof\\b(?!\\$)"
+				},
+				{
+					"name": "keyword.operator.new.js",
+					"match": "(?<!\\.|\\$)\\bnew\\b(?!\\$)"
+				},
+				{
+					"include": "#typeof-operator"
+				},
+				{
+					"name": "keyword.operator.expression.void.js",
+					"match": "(?<!\\.|\\$)\\bvoid\\b(?!\\$)"
+				},
+				{
+					"begin": "(?<!\\.|\\$)\\bas\\b(?!\\$)",
+					"beginCaptures": {
+						"0": {
+							"name": "keyword.control.as.js"
+						}
+					},
+					"end": "(?=$|[;,:})\\]])",
+					"patterns": [
+						{
+							"include": "#type"
+						}
+					]
+				},
+				{
+					"name": "keyword.operator.spread.js",
+					"match": "\\.\\.\\."
+				},
+				{
+					"name": "keyword.operator.assignment.compound.js",
+					"match": "\\*=|(?<!\\()/=|%=|\\+=|\\-="
+				},
+				{
+					"name": "keyword.operator.assignment.compound.bitwise.js",
+					"match": "\\&=|\\^=|<<=|>>=|>>>=|\\|="
+				},
+				{
+					"name": "keyword.operator.bitwise.shift.js",
+					"match": "<<|>>>|>>"
+				},
+				{
+					"name": "keyword.operator.comparison.js",
+					"match": "===|!==|==|!="
+				},
+				{
+					"name": "keyword.operator.relational.js",
+					"match": "<=|>=|<>|<|>"
+				},
+				{
+					"name": "keyword.operator.logical.js",
+					"match": "\\!|&&|\\|\\|"
+				},
+				{
+					"name": "keyword.operator.bitwise.js",
+					"match": "\\&|~|\\^|\\|"
+				},
+				{
+					"name": "keyword.operator.assignment.js",
+					"match": "\\="
+				},
+				{
+					"name": "keyword.operator.decrement.js",
+					"match": "--"
+				},
+				{
+					"name": "keyword.operator.increment.js",
+					"match": "\\+\\+"
+				},
+				{
+					"name": "keyword.operator.arithmetic.js",
+					"match": "%|\\*|/|-|\\+"
+				},
+				{
+					"match": "(?<=[_$[:alnum:]])\\s*(/)(?![/*])",
+					"captures": {
+						"1": {
+							"name": "keyword.operator.arithmetic.js"
+						}
+					}
+				}
+			]
+		},
+		"typeof-operator": {
+			"name": "keyword.operator.expression.typeof.js",
+			"match": "(?<!\\.|\\$)\\btypeof\\b(?!\\$)"
+		},
+		"arrow-function": {
+			"patterns": [
+				{
+					"name": "meta.arrow.js",
+					"match": "(?<!\\.|\\$)(\\basync)(?=\\s*[<(])",
+					"captures": {
+						"1": {
+							"name": "storage.modifier.async.js"
+						}
+					}
+				},
+				{
+					"name": "meta.arrow.js",
+					"match": "(?:(?<!\\.|\\$)(\\basync)\\s*)?([_$[:alpha:]][_$[:alnum:]]*)\\s*(?==>)",
+					"captures": {
+						"1": {
+							"name": "storage.modifier.async.js"
+						},
+						"2": {
+							"name": "variable.parameter.js"
+						}
+					}
+				},
+				{
+					"name": "meta.arrow.js",
+					"begin": "(?x)\\s*(?=(<([^<>]|\\<[^<>]+\\>)+>\\s*)?\\(([^()]|\\([^()]*\\))*\\)(\\s*:\\s*(.)*)?\\s*=>)",
+					"end": "(?==>)",
+					"patterns": [
+						{
+							"include": "#comment"
+						},
+						{
+							"include": "#type-parameters"
+						},
+						{
+							"include": "#function-parameters"
+						},
+						{
+							"include": "#arrow-return-type"
+						}
+					]
+				},
+				{
+					"name": "meta.arrow.js",
+					"begin": "=>",
+					"beginCaptures": {
+						"0": {
+							"name": "storage.type.function.arrow.js"
+						}
+					},
+					"end": "(?<=\\})|((?!\\{)(?=\\S))",
+					"patterns": [
+						{
+							"include": "#decl-block"
+						},
+						{
+							"include": "#expression"
+						}
+					]
+				}
+			]
+		},
+		"arrow-return-type": {
+			"name": "meta.return.type.arrow.js",
+			"begin": "(?<=\\))\\s*(:)",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.operator.type.annotation.js"
+				}
+			},
+			"end": "(?<!:)((?=$)|(?==>|;|//))",
+			"patterns": [
+				{
+					"include": "#type-predicate-operator"
+				},
+				{
+					"include": "#type"
+				}
+			]
+		},
+		"punctuation-comma": {
+			"name": "punctuation.separator.comma.js",
+			"match": ","
+		},
+		"punctuation-semicolon": {
+			"name": "punctuation.terminator.statement.js",
+			"match": ";"
+		},
+		"punctuation-accessor": {
+			"name": "punctuation.accessor.js",
+			"match": "\\."
+		},
+		"paren-expression": {
+			"begin": "\\(",
+			"beginCaptures": {
+				"0": {
+					"name": "meta.brace.round.js"
+				}
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": {
+					"name": "meta.brace.round.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#expression"
+				},
+				{
+					"include": "#punctuation-comma"
+				}
+			]
+		},
+		"qstring-double": {
+			"name": "string.quoted.double.js",
+			"begin": "\"",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.js"
+				}
+			},
+			"end": "(\")|((?:[^\\\\\\n])$)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.js"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#string-character-escape"
+				}
+			]
+		},
+		"qstring-single": {
+			"name": "string.quoted.single.js",
+			"begin": "'",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.js"
+				}
+			},
+			"end": "(\\')|((?:[^\\\\\\n])$)",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.js"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#string-character-escape"
+				}
+			]
+		},
+		"regex": {
+			"patterns": [
+				{
+					"name": "string.regex.js",
+					"begin": "(?<=[=(:,\\[?+!]|return|case|=>|&&|\\|\\||\\*\\/)\\s*(/)(?![/*])(?=(?:[^/\\\\\\[]|\\\\.|\\[([^\\]\\\\]|\\\\.)+\\])+/(?![/*])[gimy]*(?!\\s*[a-zA-Z0-9_$]))",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.begin.js"
+						}
+					},
+					"end": "(/)([gimuy]*)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.end.js"
+						},
+						"2": {
+							"name": "keyword.other.js"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#regexp"
+						}
+					]
+				},
+				{
+					"name": "string.regex.js",
+					"begin": "/(?![/*])(?=(?:[^/\\\\\\[]|\\\\.|\\[([^\\]\\\\]|\\\\.)+\\])+/(?![/*])[gimy]*(?!\\s*[a-zA-Z0-9_$]))",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.string.begin.js"
+						}
+					},
+					"end": "(/)([gimuy]*)",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.end.js"
+						},
+						"2": {
+							"name": "keyword.other.js"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#regexp"
+						}
+					]
+				}
+			]
+		},
+		"regexp": {
+			"patterns": [
+				{
+					"name": "keyword.control.anchor.regexp",
+					"match": "\\\\[bB]|\\^|\\$"
+				},
+				{
+					"name": "keyword.other.back-reference.regexp",
+					"match": "\\\\[1-9]\\d*"
+				},
+				{
+					"name": "keyword.operator.quantifier.regexp",
+					"match": "[?+*]|\\{(\\d+,\\d+|\\d+,|,\\d+|\\d+)\\}\\??"
+				},
+				{
+					"name": "keyword.operator.or.regexp",
+					"match": "\\|"
+				},
+				{
+					"name": "meta.group.assertion.regexp",
+					"begin": "(\\()((\\?=)|(\\?!))",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.group.regexp"
+						},
+						"2": {
+							"name": "punctuation.definition.group.assertion.regexp"
+						},
+						"3": {
+							"name": "meta.assertion.look-ahead.regexp"
+						},
+						"4": {
+							"name": "meta.assertion.negative-look-ahead.regexp"
+						}
+					},
+					"end": "(\\))",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.group.regexp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#regexp"
+						}
+					]
+				},
+				{
+					"name": "meta.group.regexp",
+					"begin": "\\((\\?:)?",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.group.regexp"
+						},
+						"1": {
+							"name": "punctuation.definition.group.capture.regexp"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.group.regexp"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#regexp"
+						}
+					]
+				},
+				{
+					"name": "constant.other.character-class.set.regexp",
+					"begin": "(\\[)(\\^)?",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.character-class.regexp"
+						},
+						"2": {
+							"name": "keyword.operator.negation.regexp"
+						}
+					},
+					"end": "(\\])",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.character-class.regexp"
+						}
+					},
+					"patterns": [
+						{
+							"name": "constant.other.character-class.range.regexp",
+							"match": "(?:.|(\\\\(?:[0-7]{3}|x\\h\\h|u\\h\\h\\h\\h))|(\\\\c[A-Z])|(\\\\.))\\-(?:[^\\]\\\\]|(\\\\(?:[0-7]{3}|x\\h\\h|u\\h\\h\\h\\h))|(\\\\c[A-Z])|(\\\\.))",
+							"captures": {
+								"1": {
+									"name": "constant.character.numeric.regexp"
+								},
+								"2": {
+									"name": "constant.character.control.regexp"
+								},
+								"3": {
+									"name": "constant.character.escape.backslash.regexp"
+								},
+								"4": {
+									"name": "constant.character.numeric.regexp"
+								},
+								"5": {
+									"name": "constant.character.control.regexp"
+								},
+								"6": {
+									"name": "constant.character.escape.backslash.regexp"
+								}
+							}
+						},
+						{
+							"include": "#regex-character-class"
+						}
+					]
+				},
+				{
+					"include": "#regex-character-class"
+				}
+			]
+		},
+		"regex-character-class": {
+			"patterns": [
+				{
+					"name": "constant.other.character-class.regexp",
+					"match": "\\\\[wWsSdDtrnvf]|\\."
+				},
+				{
+					"name": "constant.character.numeric.regexp",
+					"match": "\\\\([0-7]{3}|x\\h\\h|u\\h\\h\\h\\h)"
+				},
+				{
+					"name": "constant.character.control.regexp",
+					"match": "\\\\c[A-Z]"
+				},
+				{
+					"name": "constant.character.escape.backslash.regexp",
+					"match": "\\\\."
+				}
+			]
+		},
+		"string": {
+			"patterns": [
+				{
+					"include": "#qstring-single"
+				},
+				{
+					"include": "#qstring-double"
+				}
+			]
+		},
+		"template": {
+			"name": "string.template.js",
+			"begin": "([_$[:alpha:]][_$[:alnum:]]*)?(`)",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.name.function.tagged-template.js"
+				},
+				"2": {
+					"name": "punctuation.definition.string.template.begin.js"
+				}
+			},
+			"end": "`",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.template.end.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#template-substitution-element"
+				},
+				{
+					"include": "#string-character-escape"
+				}
+			]
+		},
+		"string-character-escape": {
+			"name": "constant.character.escape.js",
+			"match": "\\\\(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.|$)"
+		},
+		"template-substitution-element": {
+			"name": "meta.template.expression.js",
+			"begin": "\\$\\{",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.template-expression.begin.js"
+				}
+			},
+			"end": "\\}",
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.template-expression.end.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"literal": {
+			"name": "literal.js",
+			"patterns": [
+				{
+					"include": "#numeric-literal"
+				},
+				{
+					"include": "#boolean-literal"
+				},
+				{
+					"include": "#null-literal"
+				},
+				{
+					"include": "#undefined-literal"
+				},
+				{
+					"include": "#numericConstant-literal"
+				},
+				{
+					"include": "#array-literal"
+				},
+				{
+					"include": "#this-literal"
+				},
+				{
+					"include": "#super-literal"
+				}
+			]
+		},
+		"array-literal": {
+			"name": "meta.array.literal.js",
+			"begin": "\\[",
+			"beginCaptures": {
+				"0": {
+					"name": "meta.brace.square.js"
+				}
+			},
+			"end": "\\]",
+			"endCaptures": {
+				"0": {
+					"name": "meta.brace.square.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#expression"
+				},
+				{
+					"include": "#punctuation-comma"
+				}
+			]
+		},
+		"numeric-literal": {
+			"patterns": [
+				{
+					"name": "constant.numeric.hex.js",
+					"match": "\\b(?<!\\$)0(x|X)[0-9a-fA-F]+\\b(?!\\$)"
+				},
+				{
+					"name": "constant.numeric.binary.js",
+					"match": "\\b(?<!\\$)0(b|B)[01]+\\b(?!\\$)"
+				},
+				{
+					"name": "constant.numeric.octal.js",
+					"match": "\\b(?<!\\$)0(o|O)?[0-7]+\\b(?!\\$)"
+				},
+				{
+					"match": "(?x)\n(?<!\\$)(?:\n  (?:\\b[0-9]+(\\.)[0-9]+[eE][+-]?[0-9]+\\b)| # 1.1E+3\n  (?:\\b[0-9]+(\\.)[eE][+-]?[0-9]+\\b)|       # 1.E+3\n  (?:\\B(\\.)[0-9]+[eE][+-]?[0-9]+\\b)|       # .1E+3\n  (?:\\b[0-9]+[eE][+-]?[0-9]+\\b)|            # 1E+3\n  (?:\\b[0-9]+(\\.)[0-9]+\\b)|                # 1.1\n  (?:\\b[0-9]+(\\.)\\B)|                      # 1.\n  (?:\\B(\\.)[0-9]+\\b)|                      # .1\n  (?:\\b[0-9]+\\b(?!\\.))                     # 1\n)(?!\\$)",
+					"captures": {
+						"0": {
+							"name": "constant.numeric.decimal.js"
+						},
+						"1": {
+							"name": "meta.delimiter.decimal.period.js"
+						},
+						"2": {
+							"name": "meta.delimiter.decimal.period.js"
+						},
+						"3": {
+							"name": "meta.delimiter.decimal.period.js"
+						},
+						"4": {
+							"name": "meta.delimiter.decimal.period.js"
+						},
+						"5": {
+							"name": "meta.delimiter.decimal.period.js"
+						},
+						"6": {
+							"name": "meta.delimiter.decimal.period.js"
+						}
+					}
+				}
+			]
+		},
+		"boolean-literal": {
+			"patterns": [
+				{
+					"name": "constant.language.boolean.true.js",
+					"match": "(?<!\\.|\\$)\\btrue\\b(?!\\$)"
+				},
+				{
+					"name": "constant.language.boolean.false.js",
+					"match": "(?<!\\.|\\$)\\bfalse\\b(?!\\$)"
+				}
+			]
+		},
+		"null-literal": {
+			"name": "constant.language.null.js",
+			"match": "(?<!\\.|\\$)\\bnull\\b(?!\\$)"
+		},
+		"this-literal": {
+			"name": "variable.language.this.js",
+			"match": "(?<!\\.|\\$)\\bthis\\b(?!\\$)"
+		},
+		"super-literal": {
+			"name": "variable.language.super.js",
+			"match": "(?<!\\.|\\$)\\bsuper\\b(?!\\$)"
+		},
+		"undefined-literal": {
+			"name": "constant.language.undefined.js",
+			"match": "(?<!\\.|\\$)\\bundefined\\b(?!\\$)"
+		},
+		"numericConstant-literal": {
+			"patterns": [
+				{
+					"name": "constant.language.nan.js",
+					"match": "(?<!\\.|\\$)\\bNaN\\b(?!\\$)"
+				},
+				{
+					"name": "constant.language.infinity.js",
+					"match": "(?<!\\.|\\$)\\bInfinity\\b(?!\\$)"
+				}
+			]
+		},
+		"access-modifier": {
+			"name": "storage.modifier.js",
+			"match": "(?<!\\.|\\$)\\b(abstract|public|protected|private|readonly|static)\\b(?!\\$)"
+		},
+		"property-accessor": {
+			"name": "storage.type.property.js",
+			"match": "(?<!\\.|\\$)\\b(get|set)\\b(?!\\$)"
+		},
+		"comment": {
+			"patterns": [
+				{
+					"name": "comment.block.documentation.js",
+					"begin": "/\\*\\*(?!/)",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.comment.js"
+						}
+					},
+					"end": "\\*/",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.comment.js"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#docblock"
+						}
+					]
+				},
+				{
+					"name": "comment.block.js",
+					"begin": "/\\*",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.comment.js"
+						}
+					},
+					"end": "\\*/",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.comment.js"
+						}
+					}
+				},
+				{
+					"begin": "(^[ \\t]+)?(?=//)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.whitespace.comment.leading.js"
+						}
+					},
+					"end": "(?=$)",
+					"patterns": [
+						{
+							"name": "comment.line.double-slash.js",
+							"begin": "//",
+							"beginCaptures": {
+								"0": {
+									"name": "punctuation.definition.comment.js"
+								}
+							},
+							"end": "(?=$)"
+						}
+					]
+				}
+			]
+		},
+		"directives": {
+			"name": "comment.line.triple-slash.directive.js",
+			"begin": "^(///)\\s*(?=<(reference|amd-dependency|amd-module)(\\s+(path|types|no-default-lib|name)\\s*=\\s*((\\'[^']*\\')|(\\\"[^\"]*\\\")))+\\s*/>\\s*$)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.comment.js"
+				}
+			},
+			"end": "(?=$)",
+			"patterns": [
+				{
+					"name": "meta.tag.js",
+					"begin": "(<)(reference|amd-dependency|amd-module)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.directive.js"
+						},
+						"2": {
+							"name": "entity.name.tag.directive.js"
+						}
+					},
+					"end": "/>",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.tag.directive.js"
+						}
+					},
+					"patterns": [
+						{
+							"name": "entity.other.attribute-name.directive.js",
+							"match": "path|types|no-default-lib|name"
+						},
+						{
+							"name": "keyword.operator.assignment.js",
+							"match": "="
+						},
+						{
+							"include": "#string"
+						}
+					]
+				}
+			]
+		},
+		"docblock": {
+			"patterns": [
+				{
+					"name": "storage.type.class.jsdoc",
+					"match": "(?<!\\w)@(abstract|access|alias|arg|argument|async|attribute|augments|author|beta|borrows|bubbes|callback|chainable|class|classdesc|code|config|const|constant|constructor|constructs|copyright|default|defaultvalue|define|deprecated|desc|description|dict|emits|enum|event|example|exports?|extends|extension|extension_for|extensionfor|external|file|fileoverview|final|fires|for|function|global|host|ignore|implements|inherit[Dd]oc|inner|instance|interface|kind|lends|license|listens|main|member|memberof|method|mixex|mixins?|module|name|namespace|nocollapse|nosideeffects|override|overview|package|param|preserve|private|prop|property|protected|public|read[Oo]nly|record|require[ds]|returns?|see|since|static|struct|submodule|summary|template|this|throws|todo|tutorial|type|typedef|unrestricted|uses|var|variation|version|virtual|writeOnce)\\b"
+				},
+				{
+					"match": "(?x)\n(?:(?<=@param)|(?<=@arg)|(?<=@argument)|(?<=@type))\n\\s+\n({(?:\n  \\* |                                        # {*} any type\n  \\? |                                        # {?} unknown type\n  (?:                                         # Check for a prefix\n    \\? |                                      # {?string} nullable type\n    !   |                                     # {!string} non-nullable type\n    \\.{3}                                     # {...string} variable number of parameters\n  )?\n  (?:\n    \\(                                        # Opening bracket of multiple types with parenthesis {(string|number)}\n      [a-zA-Z_$]+\n      (?:\n        (?:\n          [\\w$]*\n          (?:\\[\\])?                           # {(string[]|number)} type application, an array of strings or a number\n        ) |\n        \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>            # {Array<string>} or {Object<string, number>} type application (optional .)\n      )\n      (?:\n        [\\.|~]                                # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback\n        [a-zA-Z_$]+\n        (?:\n          (?:\n            [\\w$]*\n            (?:\\[\\])?                        # {(string|number[])} type application, a string or an array of numbers\n          ) |\n          \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>         # {Array<string>} or {Object<string, number>} type application (optional .)\n        )\n      )*\n    \\) |\n    [a-zA-Z_$]+\n    (?:\n      (?:\n        [\\w$]*\n        (?:\\[\\])?                            # {string[]|number} type application, an array of strings or a number\n      ) |\n      \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>             # {Array<string>} or {Object<string, number>} type application (optional .)\n    )\n    (?:\n      [\\.|~]                                 # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback\n      [a-zA-Z_$]+\n      (?:\n        [\\w$]* |\n        \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>           # {Array<string>} or {Object<string, number>} type application (optional .)\n      )\n    )*\n  )\n                                             # Check for suffix\n  (?:\\[\\])?                                  # {string[]} type application, an array of strings\n  =?                                         # {string=} optional parameter\n)})\n\\s+\n(\n  \\[                                         # [foo] optional parameter\n    \\s*\n    (?:\n      [a-zA-Z_$][\\w$]*\n      (?:\n        (?:\\[\\])?                            # Foo[].bar properties within an array\n        \\.                                   # Foo.Bar namespaced parameter\n        [a-zA-Z_$][\\w$]*\n      )*\n      (?:\n        \\s*\n        =                                    # [foo=bar] Default parameter value\n        \\s*\n        [\\w$\\s]*\n      )?\n    )\n    \\s*\n  \\] |\n  (?:\n    [a-zA-Z_$][\\w$]*\n    (?:\n      (?:\\[\\])?                              # Foo[].bar properties within an array\n      \\.                                     # Foo.Bar namespaced parameter\n      [a-zA-Z_$][\\w$]*\n    )*\n  )?\n)\n\\s+\n(?:-\\s+)?                                    # optional hyphen before the description\n((?:(?!\\*\\/).)*)                             # The type description",
+					"captures": {
+						"0": {
+							"name": "other.meta.jsdoc"
+						},
+						"1": {
+							"name": "entity.name.type.instance.jsdoc"
+						},
+						"2": {
+							"name": "variable.other.jsdoc"
+						},
+						"3": {
+							"name": "other.description.jsdoc"
+						}
+					}
+				},
+				{
+					"match": "(?x)\n({(?:\n  \\* |                                       # {*} any type\n  \\? |                                       # {?} unknown type\n\n  (?:                                        # Check for a prefix\n    \\? |                                     # {?string} nullable type\n    !   |                                    # {!string} non-nullable type\n    \\.{3}                                    # {...string} variable number of parameters\n  )?\n\n  (?:\n    \\(                                       # Opening bracket of multiple types with parenthesis {(string|number)}\n      [a-zA-Z_$]+\n      (?:\n        [\\w$]* |\n        \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>           # {Array<string>} or {Object<string, number>} type application (optional .)\n      )\n      (?:\n        [\\.|~]                               # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback\n        [a-zA-Z_$]+\n        (?:\n          [\\w$]* |\n          \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>         # {Array<string>} or {Object<string, number>} type application (optional .)\n        )\n      )*\n    \\) |\n    [a-zA-Z_$]+\n    (?:\n      [\\w$]* |\n      \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>             # {Array<string>} or {Object<string, number>} type application (optional .)\n    )\n    (?:\n      [\\.|~]                                 # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback\n      [a-zA-Z_$]+\n      (?:\n        [\\w$]* |\n        \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>           # {Array<string>} or {Object<string, number>} type application (optional .)\n      )\n    )*\n  )\n                                             # Check for suffix\n  (?:\\[\\])?                                  # {string[]} type application, an array of strings\n  =?                                         # {string=} optional parameter\n)})\n\\s+\n(?:-\\s+)?                                    # optional hyphen before the description\n((?:(?!\\*\\/).)*)                             # The type description",
+					"captures": {
+						"0": {
+							"name": "other.meta.jsdoc"
+						},
+						"1": {
+							"name": "entity.name.type.instance.jsdoc"
+						},
+						"2": {
+							"name": "other.description.jsdoc"
+						}
+					}
+				}
+			]
+		},
+		"jsx-tag-attributes": {
+			"patterns": [
+				{
+					"include": "#jsx-tag-attribute-name"
+				},
+				{
+					"include": "#jsx-tag-attribute-assignment"
+				},
+				{
+					"include": "#jsx-string-double-quoted"
+				},
+				{
+					"include": "#jsx-string-single-quoted"
+				},
+				{
+					"include": "#jsx-evaluated-code"
+				}
+			]
+		},
+		"jsx-tag-attribute-name": {
+			"match": "(?x)\n  \\s*\n  ([_$a-zA-Z][-$\\w]*)\n  (?=\\s|=|/?>|/\\*|//)",
+			"captures": {
+				"1": {
+					"name": "entity.other.attribute-name.js"
+				}
+			}
+		},
+		"jsx-tag-attribute-assignment": {
+			"name": "keyword.operator.assignment.js",
+			"match": "=(?=\\s*(?:'|\"|{|/\\*|//|\\n))"
+		},
+		"jsx-string-double-quoted": {
+			"name": "string.quoted.double.js",
+			"begin": "\"",
+			"end": "\"",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.js"
+				}
+			},
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.end.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#jsx-entities"
+				}
+			]
+		},
+		"jsx-string-single-quoted": {
+			"name": "string.quoted.single.js",
+			"begin": "'",
+			"end": "'",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.begin.js"
+				}
+			},
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.string.end.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#jsx-entities"
+				}
+			]
+		},
+		"jsx-entities": {
+			"patterns": [
+				{
+					"name": "constant.character.entity.js",
+					"match": "(&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(;)",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.entity.js"
+						},
+						"3": {
+							"name": "punctuation.definition.entity.js"
+						}
+					}
+				},
+				{
+					"name": "invalid.illegal.bad-ampersand.js",
+					"match": "&"
+				}
+			]
+		},
+		"jsx-evaluated-code": {
+			"name": "meta.embedded.expression.js",
+			"begin": "{",
+			"end": "}",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.section.embedded.begin.js"
+				}
+			},
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.section.embedded.end.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"jsx-tag-attributes-illegal": {
+			"name": "invalid.illegal.attribute.js",
+			"match": "\\S+"
+		},
+		"jsx-tag-without-attributes": {
+			"name": "meta.tag.without-attributes.js",
+			"begin": "(<)\\s*([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\\s*(>)",
+			"end": "(</)\\s*([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\\s*(>)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag.begin.js"
+				},
+				"2": {
+					"name": "entity.name.tag.js"
+				},
+				"3": {
+					"name": "punctuation.definition.tag.end.js"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.tag.begin.js"
+				},
+				"2": {
+					"name": "entity.name.tag.js"
+				},
+				"3": {
+					"name": "punctuation.definition.tag.end.js"
+				}
+			},
+			"contentName": "meta.jsx.children.tsx",
+			"patterns": [
+				{
+					"include": "#jsx-children"
+				}
+			]
+		},
+		"jsx-tag-in-expression": {
+			"begin": "(?x)\n  (?<=[({\\[,?=>]|&&|\\|\\||\\?|\\Wreturn|^return|\\Wdefault|^)\\s*\n  (?!(<)\\s*([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\\s*(>)) #look ahead is not start of tag without attributes\n  (?!<\\s*[_$[:alpha:]][_$[:alnum:]]*((\\s+extends\\s+[^=>])|,)) # look ahead is not type parameter of arrow\n  (?=(<)\\s*\n  ([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\n  (?=\\s+(?!\\?)|/?>))",
+			"end": "(/>)|(?:(</)\\s*([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\\s*(>))",
+			"endCaptures": {
+				"0": {
+					"name": "meta.tag.js"
+				},
+				"1": {
+					"name": "punctuation.definition.tag.end.js"
+				},
+				"2": {
+					"name": "punctuation.definition.tag.begin.js"
+				},
+				"3": {
+					"name": "entity.name.tag.js"
+				},
+				"4": {
+					"name": "punctuation.definition.tag.end.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#jsx-tag"
+				}
+			]
+		},
+		"jsx-child-tag": {
+			"begin": "(?x)\n  (?=(<)\\s*\n  ([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\n  (?=\\s+(?!\\?)|/?>))",
+			"end": "(/>)|(?:(</)\\s*([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\\s*(>))",
+			"endCaptures": {
+				"0": {
+					"name": "meta.tag.js"
+				},
+				"1": {
+					"name": "punctuation.definition.tag.end.js"
+				},
+				"2": {
+					"name": "punctuation.definition.tag.begin.js"
+				},
+				"3": {
+					"name": "entity.name.tag.js"
+				},
+				"4": {
+					"name": "punctuation.definition.tag.end.js"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#jsx-tag"
+				}
+			]
+		},
+		"jsx-tag": {
+			"name": "meta.tag.js",
+			"begin": "(?x)\n  (?=(<)\\s*\n  ([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\n  (?=\\s+(?!\\?)|/?>))",
+			"end": "(?=(/>)|(?:(</)\\s*([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\\s*(>)))",
+			"patterns": [
+				{
+					"begin": "(?x)\n  (<)\\s*\n  ([_$a-zA-Z][-$\\w.]*(?<!\\.|-))\n  (?=\\s+(?!\\?)|/?>)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.begin.js"
+						},
+						"2": {
+							"name": "entity.name.tag.js"
+						}
+					},
+					"end": "(?=[/]?>)",
+					"patterns": [
+						{
+							"include": "#comment"
+						},
+						{
+							"include": "#jsx-tag-attributes"
+						},
+						{
+							"include": "#jsx-tag-attributes-illegal"
+						}
+					]
+				},
+				{
+					"begin": "(>)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.tag.end.js"
+						}
+					},
+					"end": "(?=</)",
+					"contentName": "meta.jsx.children.tsx",
+					"patterns": [
+						{
+							"include": "#jsx-children"
+						}
+					]
+				}
+			]
+		},
+		"jsx-tag-invalid": {
+			"name": "invalid.illegal.tag.incomplete.js",
+			"match": "<\\s*>"
+		},
+		"jsx-children": {
+			"patterns": [
+				{
+					"include": "#jsx-tag-without-attributes"
+				},
+				{
+					"include": "#jsx-child-tag"
+				},
+				{
+					"include": "#jsx-tag-invalid"
+				},
+				{
+					"include": "#jsx-evaluated-code"
+				},
+				{
+					"include": "#jsx-entities"
+				}
+			]
+		},
+		"jsx": {
+			"patterns": [
+				{
+					"include": "#jsx-tag-without-attributes"
+				},
+				{
+					"include": "#jsx-tag-in-expression"
+				},
+				{
+					"include": "#jsx-tag-invalid"
+				}
+			]
+		}
+	},
+	"version": "https://github.com/Microsoft/TypeScript-TmLanguage/commit/4d0bdebb93aadc25ecbb903ebc897e9cd5fab69c"
+}

--- a/microbenchmark/src/androidTest/assets/grammars/kotlin.tmLanguage.json
+++ b/microbenchmark/src/androidTest/assets/grammars/kotlin.tmLanguage.json
@@ -1,0 +1,580 @@
+{
+    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+    "name": "Kotlin",
+    "scopeName": "source.kotlin",
+    "patterns": [
+        {
+            "include": "#import"
+        },
+        {
+            "include": "#package"
+        },
+        {
+            "include": "#code"
+        }
+    ],
+    "fileTypes": [
+        "kt",
+        "kts"
+    ],
+    "repository": {
+        "import": {
+            "begin": "\\b(import)\\b\\s*",
+            "beginCaptures": {
+                "1": {
+                    "name": "keyword.soft.kotlin"
+                }
+            },
+            "end": ";|$",
+            "name": "meta.import.kotlin",
+            "contentName": "entity.name.package.kotlin",
+            "patterns": [
+                {
+                    "include": "#comments"
+                },
+                {
+                    "include": "#hard-keywords"
+                },
+                {
+                    "match": "\\*",
+                    "name": "variable.language.wildcard.kotlin"
+                }
+            ]
+        },
+        "package": {
+            "begin": "\\b(package)\\b\\s*",
+            "beginCaptures": {
+                "1": {
+                    "name": "keyword.hard.package.kotlin"
+                }
+            },
+            "end": ";|$",
+            "name": "meta.package.kotlin",
+            "contentName": "entity.name.package.kotlin",
+            "patterns": [
+                {
+                    "include": "#comments"
+                }
+            ]
+        },
+        "code": {
+            "patterns": [
+                {
+                    "include": "#comments"
+                },
+                {
+                    "include": "#keywords"
+                },
+                {
+                    "include": "#annotation-simple"
+                },
+                {
+                    "include": "#annotation-site-list"
+                },
+                {
+                    "include": "#annotation-site"
+                },
+                {
+                    "include": "#class-declaration"
+                },
+                {
+                    "include": "#object"
+                },
+                {
+                    "include": "#type-alias"
+                },
+                {
+                    "include": "#function"
+                },
+                {
+                    "include": "#variable-declaration"
+                },
+                {
+                    "include": "#type-constraint"
+                },
+                {
+                    "include": "#type-annotation"
+                },
+                {
+                    "include": "#function-call"
+                },
+                {
+                    "include": "#method-reference"
+                },
+                {
+                    "include": "#key"
+                },
+                {
+                    "include": "#string"
+                },
+                {
+                    "include": "#string-empty"
+                },
+                {
+                    "include": "#string-multiline"
+                },
+                {
+                    "include": "#character"
+                },
+                {
+                    "include": "#lambda-arrow"
+                },
+                {
+                    "include": "#operators"
+                },
+                {
+                    "include": "#self-reference"
+                },
+                {
+                    "include": "#decimal-literal"
+                },
+                {
+                    "include": "#hex-literal"
+                },
+                {
+                    "include": "#binary-literal"
+                },
+                {
+                    "include": "#boolean-literal"
+                },
+                {
+                    "include": "#null-literal"
+                }
+            ]
+        },
+        "comments": {
+            "patterns": [
+                {
+                    "include": "#comment-line"
+                },
+                {
+                    "include": "#comment-block"
+                },
+                {
+                    "include": "#comment-javadoc"
+                }
+            ]
+        },
+        "comment-line": {
+            "begin": "//",
+            "end": "$",
+            "name": "comment.line.double-slash.kotlin"
+        },
+        "comment-block": {
+            "begin": "/\\*(?!\\*)",
+            "end": "\\*/",
+            "name": "comment.block.kotlin"
+        },
+        "comment-javadoc": {
+            "patterns": [
+                {
+                    "begin": "/\\*\\*",
+                    "end": "\\*/",
+                    "name": "comment.block.javadoc.kotlin",
+                    "patterns": [
+                        {
+                            "match": "@(return|constructor|receiver|sample|see|author|since|suppress)\\b",
+                            "name": "keyword.other.documentation.javadoc.kotlin"
+                        },
+                        {
+                            "match": "(@param|@property)\\s+(\\S+)",
+                            "captures": {
+                                "1": {
+                                    "name": "keyword.other.documentation.javadoc.kotlin"
+                                },
+                                "2": {
+                                    "name": "variable.parameter.kotlin"
+                                }
+                            }
+                        },
+                        {
+                            "match": "(@param)\\[(\\S+)\\]",
+                            "captures": {
+                                "1": {
+                                    "name": "keyword.other.documentation.javadoc.kotlin"
+                                },
+                                "2": {
+                                    "name": "variable.parameter.kotlin"
+                                }
+                            }
+                        },
+                        {
+                            "match": "(@(?:exception|throws))\\s+(\\S+)",
+                            "captures": {
+                                "1": {
+                                    "name": "keyword.other.documentation.javadoc.kotlin"
+                                },
+                                "2": {
+                                    "name": "entity.name.type.class.kotlin"
+                                }
+                            }
+                        },
+                        {
+                            "match": "{(@link)\\s+(\\S+)?#([\\w$]+\\s*\\([^\\(\\)]*\\)).*}",
+                            "captures": {
+                                "1": {
+                                    "name": "keyword.other.documentation.javadoc.kotlin"
+                                },
+                                "2": {
+                                    "name": "entity.name.type.class.kotlin"
+                                },
+                                "3": {
+                                    "name": "variable.parameter.kotlin"
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "keywords": {
+            "patterns": [
+                {
+                    "include": "#prefix-modifiers"
+                },
+                {
+                    "include": "#postfix-modifiers"
+                },
+                {
+                    "include": "#soft-keywords"
+                },
+                {
+                    "include": "#hard-keywords"
+                },
+                {
+                    "include": "#control-keywords"
+                }
+            ]
+        },
+        "prefix-modifiers": {
+            "match": "\\b(abstract|final|enum|open|annotation|sealed|data|override|final|lateinit|private|protected|public|internal|inner|companion|noinline|crossinline|vararg|reified|tailrec|operator|infix|inline|external|const|suspend|value)\\b",
+            "name": "storage.modifier.other.kotlin"
+        },
+        "postfix-modifiers": {
+            "match": "\\b(where|by|get|set)\\b",
+            "name": "storage.modifier.other.kotlin"
+        },
+        "soft-keywords": {
+            "match": "\\b(init|catch|finally|field)\\b",
+            "name": "keyword.soft.kotlin"
+        },
+        "hard-keywords": {
+            "match": "\\b(as|typeof|is|in)\\b",
+            "name": "keyword.hard.kotlin"
+        },
+        "control-keywords": {
+            "match": "\\b(if|else|while|do|when|try|throw|break|continue|return|for)\\b",
+            "name": "keyword.control.kotlin"
+        },
+        "annotation-simple": {
+            "match": "(?<!\\w)@[\\w\\.]+\\b(?!:)",
+            "name": "entity.name.type.annotation.kotlin"
+        },
+        "annotation-site-list": {
+            "begin": "(?<!\\w)(@\\w+):\\s*\\[",
+            "end": "\\]",
+            "beginCaptures": {
+                "1": {
+                    "name": "entity.name.type.annotation-site.kotlin"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#unescaped-annotation"
+                }
+            ]
+        },
+        "annotation-site": {
+            "begin": "(?<!\\w)(@\\w+):\\s*(?!\\[)",
+            "end": "$",
+            "beginCaptures": {
+                "1": {
+                    "name": "entity.name.type.annotation-site.kotlin"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#unescaped-annotation"
+                }
+            ]
+        },
+        "unescaped-annotation": {
+            "match": "\\b[\\w\\.]+\\b",
+            "name": "entity.name.type.annotation.kotlin"
+        },
+        "class-declaration": {
+            "match": "\\b(class|(?:fun\\s+)?interface)\\s+(\\b\\w+\\b|`[^`]+`)\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?",
+            "captures": {
+                "1": {
+                    "name": "keyword.hard.class.kotlin"
+                },
+                "2": {
+                    "name": "entity.name.type.class.kotlin"
+                },
+                "3": {
+                    "patterns": [
+                        {
+                            "include": "#type-parameter"
+                        }
+                    ]
+                }
+            }
+        },
+        "object": {
+            "match": "\\b(object)(?:\\s+(\\b\\w+\\b|`[^`]+`))?",
+            "captures": {
+                "1": {
+                    "name": "keyword.hard.object.kotlin"
+                },
+                "2": {
+                    "name": "entity.name.type.object.kotlin"
+                }
+            }
+        },
+        "type-alias": {
+            "match": "\\b(typealias)\\s+(\\b\\w+\\b|`[^`]+`)\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?",
+            "captures": {
+                "1": {
+                    "name": "keyword.hard.typealias.kotlin"
+                },
+                "2": {
+                    "name": "entity.name.type.kotlin"
+                },
+                "3": {
+                    "patterns": [
+                        {
+                            "include": "#type-parameter"
+                        }
+                    ]
+                }
+            }
+        },
+        "function": {
+            "match": "\\b(fun)\\b\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?\\s*(?:(?:(\\w+)\\.)?(\\b\\w+\\b|`[^`]+`))?",
+            "captures": {
+                "1": {
+                    "name": "keyword.hard.fun.kotlin"
+                },
+                "2": {
+                    "patterns": [
+                        {
+                            "include": "#type-parameter"
+                        }
+                    ]
+                },
+                "4": {
+                    "name": "entity.name.type.class.extension.kotlin"
+                },
+                "5": {
+                    "name": "entity.name.function.declaration.kotlin"
+                }
+            }
+        },
+        "variable-declaration": {
+            "match": "\\b(val|var)\\b\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?",
+            "captures": {
+                "1": {
+                    "name": "keyword.hard.kotlin"
+                },
+                "2": {
+                    "patterns": [
+                        {
+                            "include": "#type-parameter"
+                        }
+                    ]
+                }
+            }
+        },
+        "type-parameter": {
+            "patterns": [
+                {
+                    "match": "\\b\\w+\\b",
+                    "name": "entity.name.type.kotlin"
+                },
+                {
+                    "match": "\\b(in|out)\\b",
+                    "name": "storage.modifier.kotlin"
+                }
+            ]
+        },
+        "type-annotation": {
+            "match": "(?<![:?]):\\s*(\\w|\\?|\\s|->|(?<GROUP>[<(]([^<>()\"']|\\g<GROUP>)+[)>]))+",
+            "captures": {
+                "0": {
+                    "patterns": [
+                        {
+                            "include": "#type-parameter"
+                        }
+                    ]
+                }
+            }
+        },
+        "function-call": {
+            "match": "\\??\\.?(\\b\\w+\\b|`[^`]+`)\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?\\s*(?=[({])",
+            "captures": {
+                "1": {
+                    "name": "entity.name.function.call.kotlin"
+                },
+                "2": {
+                    "patterns": [
+                        {
+                            "include": "#type-parameter"
+                        }
+                    ]
+                }
+            }
+        },
+        "method-reference": {
+            "match": "\\??::(\\b\\w+\\b|`[^`]+`)",
+            "captures": {
+                "1": {
+                    "name": "entity.name.function.reference.kotlin"
+                }
+            }
+        },
+        "key": {
+            "match": "\\b(\\w=)\\s*(=)",
+            "captures": {
+                "1": {
+                    "name": "variable.parameter.kotlin"
+                },
+                "2": {
+                    "name": "keyword.operator.assignment.kotlin"
+                }
+            }
+        },
+        "string-empty": {
+            "match": "(?<!\")\"\"(?!\")",
+            "name": "string.quoted.double.kotlin"
+        },
+        "string": {
+            "begin": "(?<!\")\"(?!\")",
+            "end": "\"",
+            "name": "string.quoted.double.kotlin",
+            "patterns": [
+                {
+                    "match": "\\\\.",
+                    "name": "constant.character.escape.kotlin"
+                },
+                {
+                    "include": "#string-escape-simple"
+                },
+                {
+                    "include": "#string-escape-bracketed"
+                }
+            ]
+        },
+        "string-multiline": {
+            "begin": "\"\"\"",
+            "end": "\"\"\"",
+            "name": "string.quoted.double.kotlin",
+            "patterns": [
+                {
+                    "match": "\\\\.",
+                    "name": "constant.character.escape.kotlin"
+                },
+                {
+                    "include": "#string-escape-simple"
+                },
+                {
+                    "include": "#string-escape-bracketed"
+                }
+            ]
+        },
+        "string-escape-simple": {
+            "match": "(?<!\\\\)\\$\\w+\\b",
+            "name": "variable.string-escape.kotlin"
+        },
+        "string-escape-bracketed": {
+            "begin": "(?<!\\\\)(\\$\\{)",
+            "end": "(\\})",
+            "name": "meta.template.expression.kotlin",
+            "beginCaptures": {
+                "1": {
+                    "name": "punctuation.definition.template-expression.begin"
+                }
+            },
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.definition.template-expression.end"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#code"
+                }
+            ]
+        },
+        "character": {
+            "begin": "'",
+            "end": "'",
+            "name": "string.quoted.single.kotlin",
+            "patterns": [
+                {
+                    "match": "\\\\.",
+                    "name": "constant.character.escape.kotlin"
+                }
+            ]
+        },
+        "decimal-literal": {
+            "match": "\\b\\d[\\d_]*(\\.[\\d_]+)?((e|E)\\d+)?(u|U)?(L|F|f)?\\b",
+            "name": "constant.numeric.decimal.kotlin"
+        },
+        "hex-literal": {
+            "match": "0(x|X)[A-Fa-f0-9][A-Fa-f0-9_]*(u|U)?",
+            "name": "constant.numeric.hex.kotlin"
+        },
+        "binary-literal": {
+            "match": "0(b|B)[01][01_]*",
+            "name": "constant.numeric.binary.kotlin"
+        },
+        "boolean-literal": {
+            "match": "\\b(true|false)\\b",
+            "name": "constant.language.boolean.kotlin"
+        },
+        "null-literal": {
+            "match": "\\bnull\\b",
+            "name": "constant.language.null.kotlin"
+        },
+        "lambda-arrow": {
+            "match": "->",
+            "name": "storage.type.function.arrow.kotlin"
+        },
+        "operators": {
+            "patterns": [
+                {
+                    "match": "(===?|\\!==?|<=|>=|<|>)",
+                    "name": "keyword.operator.comparison.kotlin"
+                },
+                {
+                    "match": "([+*/%-]=)",
+                    "name": "keyword.operator.assignment.arithmetic.kotlin"
+                },
+                {
+                    "match": "(=)",
+                    "name": "keyword.operator.assignment.kotlin"
+                },
+                {
+                    "match": "([+*/%-])",
+                    "name": "keyword.operator.arithmetic.kotlin"
+                },
+                {
+                    "match": "(!|&&|\\|\\|)",
+                    "name": "keyword.operator.logical.kotlin"
+                },
+                {
+                    "match": "(--|\\+\\+)",
+                    "name": "keyword.operator.increment-decrement.kotlin"
+                },
+                {
+                    "match": "(\\.\\.)",
+                    "name": "keyword.operator.range.kotlin"
+                }
+            ]
+        },
+        "self-reference": {
+            "match": "\\b(this|super)(@\\w+)?\\b",
+            "name": "variable.language.this.kotlin"
+        }
+    }
+}

--- a/microbenchmark/src/androidTest/assets/grammars/python.tmLanguage.json
+++ b/microbenchmark/src/androidTest/assets/grammars/python.tmLanguage.json
@@ -1,0 +1,4213 @@
+{
+	"information_for_contributors": [
+		"This file has been converted from https://github.com/MagicStack/MagicPython/blob/master/grammars/MagicPython.tmLanguage",
+		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
+		"Once accepted there, we are happy to receive an update request."
+	],
+	"version": "https://github.com/MagicStack/MagicPython/commit/7d0f2b22a5ad8fccbd7341bc7b7a715169283044",
+	"name": "MagicPython",
+	"scopeName": "source.python",
+	"patterns": [
+		{
+			"include": "#statement"
+		},
+		{
+			"include": "#expression"
+		}
+	],
+	"repository": {
+		"impossible": {
+			"comment": "This is a special rule that should be used where no match is desired. It is not a good idea to match something like '1{0}' because in some cases that can result in infinite loops in token generation. So the rule instead matches and impossible expression to allow a match to fail and move to the next token.",
+			"match": "$.^"
+		},
+		"statement": {
+			"patterns": [
+				{
+					"include": "#import"
+				},
+				{
+					"include": "#class-declaration"
+				},
+				{
+					"include": "#function-declaration"
+				},
+				{
+					"include": "#generator"
+				},
+				{
+					"include": "#statement-keyword"
+				},
+				{
+					"include": "#assignment-operator"
+				},
+				{
+					"include": "#decorator"
+				},
+				{
+					"include": "#docstring-statement"
+				},
+				{
+					"include": "#semicolon"
+				}
+			]
+		},
+		"semicolon": {
+			"patterns": [
+				{
+					"name": "invalid.deprecated.semicolon.python",
+					"match": "\\;$"
+				}
+			]
+		},
+		"comments": {
+			"patterns": [
+				{
+					"name": "comment.line.number-sign.python",
+					"contentName": "meta.typehint.comment.python",
+					"begin": "(?x)\n  (?:\n    \\# \\s* (type:)\n    \\s*+ (?# we want `\\s*+` which is possessive quantifier since\n             we do not actually want to backtrack when matching\n             whitespace here)\n    (?! $ | \\#)\n  )\n",
+					"end": "(?:$|(?=\\#))",
+					"beginCaptures": {
+						"0": {
+							"name": "meta.typehint.comment.python"
+						},
+						"1": {
+							"name": "comment.typehint.directive.notation.python"
+						}
+					},
+					"patterns": [
+						{
+							"name": "comment.typehint.ignore.notation.python",
+							"match": "(?x)\n  \\G ignore\n  (?= \\s* (?: $ | \\#))\n"
+						},
+						{
+							"name": "comment.typehint.type.notation.python",
+							"match": "(?x)\n  (?<!\\.)\\b(\n    bool | bytes | float | int | object | str\n    | List | Dict | Iterable | Sequence | Set\n    | FrozenSet | Callable | Union | Tuple\n    | Any | None\n  )\\b\n"
+						},
+						{
+							"name": "comment.typehint.punctuation.notation.python",
+							"match": "([\\[\\]\\(\\),\\.\\=\\*]|(->))"
+						},
+						{
+							"name": "comment.typehint.variable.notation.python",
+							"match": "([[:alpha:]_]\\w*)"
+						}
+					]
+				},
+				{
+					"include": "#comments-base"
+				}
+			]
+		},
+		"docstring-statement": {
+			"begin": "^(?=\\s*[rR]?(\\'\\'\\'|\\\"\\\"\\\"|\\'|\\\"))",
+			"comment": "the string either terminates correctly or by the beginning of a new line (this is for single line docstrings that aren't terminated) AND it's not followed by another docstring",
+			"end": "((?<=\\1)|^)(?!\\s*[rR]?(\\'\\'\\'|\\\"\\\"\\\"|\\'|\\\"))",
+			"patterns": [
+				{
+					"include": "#docstring"
+				}
+			]
+		},
+		"docstring": {
+			"patterns": [
+				{
+					"name": "string.quoted.docstring.multi.python",
+					"begin": "(\\'\\'\\'|\\\"\\\"\\\")",
+					"end": "(\\1)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.begin.python"
+						}
+					},
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.end.python"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#docstring-prompt"
+						},
+						{
+							"include": "#codetags"
+						},
+						{
+							"include": "#docstring-guts-unicode"
+						}
+					]
+				},
+				{
+					"name": "string.quoted.docstring.raw.multi.python",
+					"begin": "([rR])(\\'\\'\\'|\\\"\\\"\\\")",
+					"end": "(\\2)",
+					"beginCaptures": {
+						"1": {
+							"name": "storage.type.string.python"
+						},
+						"2": {
+							"name": "punctuation.definition.string.begin.python"
+						}
+					},
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.end.python"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#string-consume-escape"
+						},
+						{
+							"include": "#docstring-prompt"
+						},
+						{
+							"include": "#codetags"
+						}
+					]
+				},
+				{
+					"name": "string.quoted.docstring.single.python",
+					"begin": "(\\'|\\\")",
+					"end": "(\\1)|(\\n)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.begin.python"
+						}
+					},
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.end.python"
+						},
+						"2": {
+							"name": "invalid.illegal.newline.python"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#codetags"
+						},
+						{
+							"include": "#docstring-guts-unicode"
+						}
+					]
+				},
+				{
+					"name": "string.quoted.docstring.raw.single.python",
+					"begin": "([rR])(\\'|\\\")",
+					"end": "(\\2)|(\\n)",
+					"beginCaptures": {
+						"1": {
+							"name": "storage.type.string.python"
+						},
+						"2": {
+							"name": "punctuation.definition.string.begin.python"
+						}
+					},
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.end.python"
+						},
+						"2": {
+							"name": "invalid.illegal.newline.python"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#string-consume-escape"
+						},
+						{
+							"include": "#codetags"
+						}
+					]
+				}
+			]
+		},
+		"docstring-guts-unicode": {
+			"patterns": [
+				{
+					"include": "#escape-sequence-unicode"
+				},
+				{
+					"include": "#escape-sequence"
+				},
+				{
+					"include": "#string-line-continuation"
+				}
+			]
+		},
+		"docstring-prompt": {
+			"match": "(?x)\n  (?:\n    (?:^|\\G) \\s* (?# '\\G' is necessary for ST)\n    ((?:>>>|\\.\\.\\.) \\s) (?=\\s*\\S)\n  )\n",
+			"captures": {
+				"1": {
+					"name": "keyword.control.flow.python"
+				}
+			}
+		},
+		"statement-keyword": {
+			"patterns": [
+				{
+					"name": "storage.type.function.python",
+					"match": "\\b((async\\s+)?\\s*def)\\b"
+				},
+				{
+					"name": "keyword.control.flow.python",
+					"comment": "if `as` is eventually followed by `:` or line continuation\nit's probably control flow like:\n    with foo as bar, \\\n         Foo as Bar:\n      try:\n        do_stuff()\n      except Exception as e:\n        pass\n",
+					"match": "\\b(?<!\\.)as\\b(?=.*[:\\\\])"
+				},
+				{
+					"name": "keyword.control.import.python",
+					"comment": "other legal use of `as` is in an import",
+					"match": "\\b(?<!\\.)as\\b"
+				},
+				{
+					"name": "keyword.control.flow.python",
+					"match": "(?x)\n  \\b(?<!\\.)(\n    async | continue | del | assert | break | finally | for\n    | from | elif | else | if | except | pass | raise\n    | return | try | while | with\n  )\\b\n"
+				},
+				{
+					"name": "storage.modifier.declaration.python",
+					"match": "(?x)\n  \\b(?<!\\.)(\n    global | nonlocal\n  )\\b\n"
+				},
+				{
+					"name": "storage.type.class.python",
+					"match": "\\b(?<!\\.)(class)\\b"
+				},
+				{
+					"match": "(?x)\n  ^\\s*(\n    case | match\n  )(?=\\s*([-+\\w\\d(\\[{'\":#]|$))\\b\n",
+					"captures": {
+						"1": {
+							"name": "keyword.control.flow.python"
+						}
+					}
+				}
+			]
+		},
+		"expression-bare": {
+			"comment": "valid Python expressions w/o comments and line continuation",
+			"patterns": [
+				{
+					"include": "#backticks"
+				},
+				{
+					"include": "#illegal-anno"
+				},
+				{
+					"include": "#literal"
+				},
+				{
+					"include": "#regexp"
+				},
+				{
+					"include": "#string"
+				},
+				{
+					"include": "#lambda"
+				},
+				{
+					"include": "#generator"
+				},
+				{
+					"include": "#illegal-operator"
+				},
+				{
+					"include": "#operator"
+				},
+				{
+					"include": "#curly-braces"
+				},
+				{
+					"include": "#item-access"
+				},
+				{
+					"include": "#list"
+				},
+				{
+					"include": "#odd-function-call"
+				},
+				{
+					"include": "#round-braces"
+				},
+				{
+					"include": "#function-call"
+				},
+				{
+					"include": "#builtin-functions"
+				},
+				{
+					"include": "#builtin-types"
+				},
+				{
+					"include": "#builtin-exceptions"
+				},
+				{
+					"include": "#magic-names"
+				},
+				{
+					"include": "#special-names"
+				},
+				{
+					"include": "#illegal-names"
+				},
+				{
+					"include": "#special-variables"
+				},
+				{
+					"include": "#ellipsis"
+				},
+				{
+					"include": "#punctuation"
+				},
+				{
+					"include": "#line-continuation"
+				}
+			]
+		},
+		"expression-base": {
+			"comment": "valid Python expressions with comments and line continuation",
+			"patterns": [
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#expression-bare"
+				},
+				{
+					"include": "#line-continuation"
+				}
+			]
+		},
+		"expression": {
+			"comment": "All valid Python expressions",
+			"patterns": [
+				{
+					"include": "#expression-base"
+				},
+				{
+					"include": "#member-access"
+				},
+				{
+					"comment": "Tokenize identifiers to help linters",
+					"match": "(?x) \\b ([[:alpha:]_]\\w*) \\b"
+				}
+			]
+		},
+		"member-access": {
+			"name": "meta.member.access.python",
+			"begin": "(\\.)\\s*(?!\\.)",
+			"end": "(?x)\n  # stop when you've just read non-whitespace followed by non-word\n  # i.e. when finished reading an identifier or function call\n  (?<=\\S)(?=\\W) |\n  # stop when seeing the start of something that's not a word,\n  # i.e. when seeing a non-identifier\n  (^|(?<=\\s))(?=[^\\\\\\w\\s]) |\n  $\n",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.separator.period.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#function-call"
+				},
+				{
+					"include": "#member-access-base"
+				},
+				{
+					"include": "#member-access-attribute"
+				}
+			]
+		},
+		"member-access-base": {
+			"patterns": [
+				{
+					"include": "#magic-names"
+				},
+				{
+					"include": "#illegal-names"
+				},
+				{
+					"include": "#illegal-object-name"
+				},
+				{
+					"include": "#special-names"
+				},
+				{
+					"include": "#line-continuation"
+				},
+				{
+					"include": "#item-access"
+				}
+			]
+		},
+		"member-access-attribute": {
+			"comment": "Highlight attribute access in otherwise non-specialized cases.",
+			"name": "meta.attribute.python",
+			"match": "(?x)\n  \\b ([[:alpha:]_]\\w*) \\b\n"
+		},
+		"special-names": {
+			"name": "constant.other.caps.python",
+			"match": "(?x)\n  \\b\n    # we want to see \"enough\", meaning 2 or more upper-case\n    # letters in the beginning of the constant\n    #\n    # for more details refer to:\n    #   https://github.com/MagicStack/MagicPython/issues/42\n    (\n      _* [[:upper:]] [_\\d]* [[:upper:]]\n    )\n    [[:upper:]\\d]* (_\\w*)?\n  \\b\n"
+		},
+		"curly-braces": {
+			"begin": "\\{",
+			"end": "\\}",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.dict.begin.python"
+				}
+			},
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.dict.end.python"
+				}
+			},
+			"patterns": [
+				{
+					"name": "punctuation.separator.dict.python",
+					"match": ":"
+				},
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"list": {
+			"begin": "\\[",
+			"end": "\\]",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.definition.list.begin.python"
+				}
+			},
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.definition.list.end.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"odd-function-call": {
+			"comment": "A bit obscured function call where there may have been an\narbitrary number of other operations to get the function.\nE.g. \"arr[idx](args)\"\n",
+			"begin": "(?x)\n  (?<= \\] | \\) ) \\s*\n  (?=\\()\n",
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.arguments.end.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#function-arguments"
+				}
+			]
+		},
+		"round-braces": {
+			"begin": "\\(",
+			"end": "\\)",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.parenthesis.begin.python"
+				}
+			},
+			"endCaptures": {
+				"0": {
+					"name": "punctuation.parenthesis.end.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"line-continuation": {
+			"patterns": [
+				{
+					"match": "(\\\\)\\s*(\\S.*$\\n?)",
+					"captures": {
+						"1": {
+							"name": "punctuation.separator.continuation.line.python"
+						},
+						"2": {
+							"name": "invalid.illegal.line.continuation.python"
+						}
+					}
+				},
+				{
+					"begin": "(\\\\)\\s*$\\n?",
+					"end": "(?x)\n  (?=^\\s*$)\n  |\n  (?! (\\s* [rR]? (\\'\\'\\'|\\\"\\\"\\\"|\\'|\\\"))\n      |\n      (\\G $)  (?# '\\G' is necessary for ST)\n  )\n",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.separator.continuation.line.python"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#regexp"
+						},
+						{
+							"include": "#string"
+						}
+					]
+				}
+			]
+		},
+		"assignment-operator": {
+			"name": "keyword.operator.assignment.python",
+			"match": "(?x)\n     <<= | >>= | //= | \\*\\*=\n    | \\+= | -= | /= | @=\n    | \\*= | %= | ~= | \\^= | &= | \\|=\n    | =(?!=)\n"
+		},
+		"operator": {
+			"match": "(?x)\n    \\b(?<!\\.)\n      (?:\n        (and | or | not | in | is)                         (?# 1)\n        |\n        (for | if | else | await | (?:yield(?:\\s+from)?))  (?# 2)\n      )\n    (?!\\s*:)\\b\n\n    | (<< | >> | & | \\| | \\^ | ~)                          (?# 3)\n\n    | (\\*\\* | \\* | \\+ | - | % | // | / | @)                (?# 4)\n\n    | (!= | == | >= | <= | < | >)                          (?# 5)\n\n    | (:=)                                                 (?# 6)\n",
+			"captures": {
+				"1": {
+					"name": "keyword.operator.logical.python"
+				},
+				"2": {
+					"name": "keyword.control.flow.python"
+				},
+				"3": {
+					"name": "keyword.operator.bitwise.python"
+				},
+				"4": {
+					"name": "keyword.operator.arithmetic.python"
+				},
+				"5": {
+					"name": "keyword.operator.comparison.python"
+				},
+				"6": {
+					"name": "keyword.operator.assignment.python"
+				}
+			}
+		},
+		"punctuation": {
+			"patterns": [
+				{
+					"name": "punctuation.separator.colon.python",
+					"match": ":"
+				},
+				{
+					"name": "punctuation.separator.element.python",
+					"match": ","
+				}
+			]
+		},
+		"literal": {
+			"patterns": [
+				{
+					"name": "constant.language.python",
+					"match": "\\b(True|False|None|NotImplemented|Ellipsis)\\b"
+				},
+				{
+					"include": "#number"
+				}
+			]
+		},
+		"number": {
+			"name": "constant.numeric.python",
+			"patterns": [
+				{
+					"include": "#number-float"
+				},
+				{
+					"include": "#number-dec"
+				},
+				{
+					"include": "#number-hex"
+				},
+				{
+					"include": "#number-oct"
+				},
+				{
+					"include": "#number-bin"
+				},
+				{
+					"include": "#number-long"
+				},
+				{
+					"name": "invalid.illegal.name.python",
+					"match": "\\b[0-9]+\\w+"
+				}
+			]
+		},
+		"number-float": {
+			"name": "constant.numeric.float.python",
+			"match": "(?x)\n  (?<! \\w)(?:\n    (?:\n      \\.[0-9](?: _?[0-9] )*\n      |\n      [0-9](?: _?[0-9] )* \\. [0-9](?: _?[0-9] )*\n      |\n      [0-9](?: _?[0-9] )* \\.\n    ) (?: [eE][+-]?[0-9](?: _?[0-9] )* )?\n    |\n    [0-9](?: _?[0-9] )* (?: [eE][+-]?[0-9](?: _?[0-9] )* )\n  )([jJ])?\\b\n",
+			"captures": {
+				"1": {
+					"name": "storage.type.imaginary.number.python"
+				}
+			}
+		},
+		"number-dec": {
+			"name": "constant.numeric.dec.python",
+			"match": "(?x)\n  (?<![\\w\\.])(?:\n      [1-9](?: _?[0-9] )*\n      |\n      0+\n      |\n      [0-9](?: _?[0-9] )* ([jJ])\n      |\n      0 ([0-9]+)(?![eE\\.])\n  )\\b\n",
+			"captures": {
+				"1": {
+					"name": "storage.type.imaginary.number.python"
+				},
+				"2": {
+					"name": "invalid.illegal.dec.python"
+				}
+			}
+		},
+		"number-hex": {
+			"name": "constant.numeric.hex.python",
+			"match": "(?x)\n  (?<![\\w\\.])\n    (0[xX]) (_?[0-9a-fA-F])+\n  \\b\n",
+			"captures": {
+				"1": {
+					"name": "storage.type.number.python"
+				}
+			}
+		},
+		"number-oct": {
+			"name": "constant.numeric.oct.python",
+			"match": "(?x)\n  (?<![\\w\\.])\n    (0[oO]) (_?[0-7])+\n  \\b\n",
+			"captures": {
+				"1": {
+					"name": "storage.type.number.python"
+				}
+			}
+		},
+		"number-bin": {
+			"name": "constant.numeric.bin.python",
+			"match": "(?x)\n  (?<![\\w\\.])\n    (0[bB]) (_?[01])+\n  \\b\n",
+			"captures": {
+				"1": {
+					"name": "storage.type.number.python"
+				}
+			}
+		},
+		"number-long": {
+			"name": "constant.numeric.bin.python",
+			"comment": "this is to support python2 syntax for long ints",
+			"match": "(?x)\n  (?<![\\w\\.])\n    ([1-9][0-9]* | 0) ([lL])\n  \\b\n",
+			"captures": {
+				"2": {
+					"name": "storage.type.number.python"
+				}
+			}
+		},
+		"regexp": {
+			"patterns": [
+				{
+					"include": "#regexp-single-three-line"
+				},
+				{
+					"include": "#regexp-double-three-line"
+				},
+				{
+					"include": "#regexp-single-one-line"
+				},
+				{
+					"include": "#regexp-double-one-line"
+				}
+			]
+		},
+		"string": {
+			"patterns": [
+				{
+					"include": "#string-quoted-multi-line"
+				},
+				{
+					"include": "#string-quoted-single-line"
+				},
+				{
+					"include": "#string-bin-quoted-multi-line"
+				},
+				{
+					"include": "#string-bin-quoted-single-line"
+				},
+				{
+					"include": "#string-raw-quoted-multi-line"
+				},
+				{
+					"include": "#string-raw-quoted-single-line"
+				},
+				{
+					"include": "#string-raw-bin-quoted-multi-line"
+				},
+				{
+					"include": "#string-raw-bin-quoted-single-line"
+				},
+				{
+					"include": "#fstring-fnorm-quoted-multi-line"
+				},
+				{
+					"include": "#fstring-fnorm-quoted-single-line"
+				},
+				{
+					"include": "#fstring-normf-quoted-multi-line"
+				},
+				{
+					"include": "#fstring-normf-quoted-single-line"
+				},
+				{
+					"include": "#fstring-raw-quoted-multi-line"
+				},
+				{
+					"include": "#fstring-raw-quoted-single-line"
+				}
+			]
+		},
+		"string-unicode-guts": {
+			"patterns": [
+				{
+					"include": "#escape-sequence-unicode"
+				},
+				{
+					"include": "#string-entity"
+				},
+				{
+					"include": "#string-brace-formatting"
+				}
+			]
+		},
+		"string-consume-escape": {
+			"match": "\\\\['\"\\n\\\\]"
+		},
+		"string-raw-guts": {
+			"patterns": [
+				{
+					"include": "#string-consume-escape"
+				},
+				{
+					"include": "#string-formatting"
+				},
+				{
+					"include": "#string-brace-formatting"
+				}
+			]
+		},
+		"string-raw-bin-guts": {
+			"patterns": [
+				{
+					"include": "#string-consume-escape"
+				},
+				{
+					"include": "#string-formatting"
+				}
+			]
+		},
+		"string-entity": {
+			"patterns": [
+				{
+					"include": "#escape-sequence"
+				},
+				{
+					"include": "#string-line-continuation"
+				},
+				{
+					"include": "#string-formatting"
+				}
+			]
+		},
+		"fstring-guts": {
+			"patterns": [
+				{
+					"include": "#escape-sequence-unicode"
+				},
+				{
+					"include": "#escape-sequence"
+				},
+				{
+					"include": "#string-line-continuation"
+				},
+				{
+					"include": "#fstring-formatting"
+				}
+			]
+		},
+		"fstring-raw-guts": {
+			"patterns": [
+				{
+					"include": "#string-consume-escape"
+				},
+				{
+					"include": "#fstring-formatting"
+				}
+			]
+		},
+		"fstring-illegal-single-brace": {
+			"comment": "it is illegal to have a multiline brace inside a single-line string",
+			"begin": "(\\{)(?=[^\\n}]*$\\n?)",
+			"end": "(\\})|(?=\\n)",
+			"beginCaptures": {
+				"1": {
+					"name": "constant.character.format.placeholder.other.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "constant.character.format.placeholder.other.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#fstring-terminator-single"
+				},
+				{
+					"include": "#f-expression"
+				}
+			]
+		},
+		"fstring-illegal-multi-brace": {
+			"patterns": [
+				{
+					"include": "#impossible"
+				}
+			]
+		},
+		"f-expression": {
+			"comment": "All valid Python expressions, except comments and line continuation",
+			"patterns": [
+				{
+					"include": "#expression-bare"
+				},
+				{
+					"include": "#member-access"
+				},
+				{
+					"comment": "Tokenize identifiers to help linters",
+					"match": "(?x) \\b ([[:alpha:]_]\\w*) \\b"
+				}
+			]
+		},
+		"escape-sequence-unicode": {
+			"patterns": [
+				{
+					"name": "constant.character.escape.python",
+					"match": "(?x)\n  \\\\ (\n        u[0-9A-Fa-f]{4}\n        | U[0-9A-Fa-f]{8}\n        | N\\{[\\w\\s]+?\\}\n     )\n"
+				}
+			]
+		},
+		"escape-sequence": {
+			"name": "constant.character.escape.python",
+			"match": "(?x)\n  \\\\ (\n        x[0-9A-Fa-f]{2}\n        | [0-7]{1,3}\n        | [\\\\\"'abfnrtv]\n     )\n"
+		},
+		"string-line-continuation": {
+			"name": "constant.language.python",
+			"match": "\\\\$"
+		},
+		"string-formatting": {
+			"name": "meta.format.percent.python",
+			"match": "(?x)\n  (\n    % (\\([\\w\\s]*\\))?\n      [-+#0 ]*\n      (\\d+|\\*)? (\\.(\\d+|\\*))?\n      ([hlL])?\n      [diouxXeEfFgGcrsab%]\n  )\n",
+			"captures": {
+				"1": {
+					"name": "constant.character.format.placeholder.other.python"
+				}
+			}
+		},
+		"string-brace-formatting": {
+			"patterns": [
+				{
+					"name": "meta.format.brace.python",
+					"match": "(?x)\n  (\n    {{ | }}\n    | (?:\n      {\n        \\w* (\\.[[:alpha:]_]\\w* | \\[[^\\]'\"]+\\])*\n        (![rsa])?\n        ( : \\w? [<>=^]? [-+ ]? \\#?\n          \\d* ,? (\\.\\d+)? [bcdeEfFgGnosxX%]? )?\n      })\n  )\n",
+					"captures": {
+						"1": {
+							"name": "constant.character.format.placeholder.other.python"
+						},
+						"3": {
+							"name": "storage.type.format.python"
+						},
+						"4": {
+							"name": "storage.type.format.python"
+						}
+					}
+				},
+				{
+					"name": "meta.format.brace.python",
+					"match": "(?x)\n  (\n    {\n      \\w* (\\.[[:alpha:]_]\\w* | \\[[^\\]'\"]+\\])*\n      (![rsa])?\n      (:)\n        [^'\"{}\\n]* (?:\n          \\{ [^'\"}\\n]*? \\} [^'\"{}\\n]*\n        )*\n    }\n  )\n",
+					"captures": {
+						"1": {
+							"name": "constant.character.format.placeholder.other.python"
+						},
+						"3": {
+							"name": "storage.type.format.python"
+						},
+						"4": {
+							"name": "storage.type.format.python"
+						}
+					}
+				}
+			]
+		},
+		"fstring-formatting": {
+			"patterns": [
+				{
+					"include": "#fstring-formatting-braces"
+				},
+				{
+					"include": "#fstring-formatting-singe-brace"
+				}
+			]
+		},
+		"fstring-formatting-singe-brace": {
+			"name": "invalid.illegal.brace.python",
+			"match": "(}(?!}))"
+		},
+		"import": {
+			"comment": "Import statements used to correctly mark `from`, `import`, and `as`\n",
+			"patterns": [
+				{
+					"begin": "\\b(?<!\\.)(from)\\b(?=.+import)",
+					"end": "$|(?=import)",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.control.import.python"
+						}
+					},
+					"patterns": [
+						{
+							"name": "punctuation.separator.period.python",
+							"match": "\\.+"
+						},
+						{
+							"include": "#expression"
+						}
+					]
+				},
+				{
+					"begin": "\\b(?<!\\.)(import)\\b",
+					"end": "$",
+					"beginCaptures": {
+						"1": {
+							"name": "keyword.control.import.python"
+						}
+					},
+					"patterns": [
+						{
+							"name": "keyword.control.import.python",
+							"match": "\\b(?<!\\.)as\\b"
+						},
+						{
+							"include": "#expression"
+						}
+					]
+				}
+			]
+		},
+		"class-declaration": {
+			"patterns": [
+				{
+					"name": "meta.class.python",
+					"begin": "(?x)\n  \\s*(class)\\s+\n    (?=\n      [[:alpha:]_]\\w* \\s* (:|\\()\n    )\n",
+					"end": "(:)",
+					"beginCaptures": {
+						"1": {
+							"name": "storage.type.class.python"
+						}
+					},
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.class.begin.python"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#class-name"
+						},
+						{
+							"include": "#class-inheritance"
+						}
+					]
+				}
+			]
+		},
+		"class-name": {
+			"patterns": [
+				{
+					"include": "#illegal-object-name"
+				},
+				{
+					"include": "#builtin-possible-callables"
+				},
+				{
+					"name": "entity.name.type.class.python",
+					"match": "(?x)\n  \\b ([[:alpha:]_]\\w*) \\b\n"
+				}
+			]
+		},
+		"class-inheritance": {
+			"name": "meta.class.inheritance.python",
+			"begin": "(\\()",
+			"end": "(\\))",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.inheritance.begin.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.inheritance.end.python"
+				}
+			},
+			"patterns": [
+				{
+					"name": "keyword.operator.unpacking.arguments.python",
+					"match": "(\\*\\*|\\*)"
+				},
+				{
+					"name": "punctuation.separator.inheritance.python",
+					"match": ","
+				},
+				{
+					"name": "keyword.operator.assignment.python",
+					"match": "=(?!=)"
+				},
+				{
+					"name": "support.type.metaclass.python",
+					"match": "\\bmetaclass\\b"
+				},
+				{
+					"include": "#illegal-names"
+				},
+				{
+					"include": "#class-kwarg"
+				},
+				{
+					"include": "#call-wrapper-inheritance"
+				},
+				{
+					"include": "#expression-base"
+				},
+				{
+					"include": "#member-access-class"
+				},
+				{
+					"include": "#inheritance-identifier"
+				}
+			]
+		},
+		"class-kwarg": {
+			"match": "(?x)\n  \\b ([[:alpha:]_]\\w*) \\s*(=)(?!=)\n",
+			"captures": {
+				"1": {
+					"name": "entity.other.inherited-class.python variable.parameter.class.python"
+				},
+				"2": {
+					"name": "keyword.operator.assignment.python"
+				}
+			}
+		},
+		"inheritance-identifier": {
+			"match": "(?x)\n  \\b ([[:alpha:]_]\\w*) \\b\n",
+			"captures": {
+				"1": {
+					"name": "entity.other.inherited-class.python"
+				}
+			}
+		},
+		"member-access-class": {
+			"name": "meta.member.access.python",
+			"begin": "(\\.)\\s*(?!\\.)",
+			"end": "(?<=\\S)(?=\\W)|$",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.separator.period.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#call-wrapper-inheritance"
+				},
+				{
+					"include": "#member-access-base"
+				},
+				{
+					"include": "#inheritance-identifier"
+				}
+			]
+		},
+		"lambda": {
+			"patterns": [
+				{
+					"match": "((?<=\\.)lambda|lambda(?=\\s*[\\.=]))",
+					"captures": {
+						"1": {
+							"name": "keyword.control.flow.python"
+						}
+					}
+				},
+				{
+					"match": "\\b(lambda)\\s*?(?=[,\\n]|$)",
+					"captures": {
+						"1": {
+							"name": "storage.type.function.lambda.python"
+						}
+					}
+				},
+				{
+					"name": "meta.lambda-function.python",
+					"begin": "(?x)\n  \\b (lambda) \\b\n",
+					"end": "(:)|(\\n)",
+					"beginCaptures": {
+						"1": {
+							"name": "storage.type.function.lambda.python"
+						}
+					},
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.section.function.lambda.begin.python"
+						}
+					},
+					"contentName": "meta.function.lambda.parameters.python",
+					"patterns": [
+						{
+							"name": "keyword.operator.positional.parameter.python",
+							"match": "/"
+						},
+						{
+							"name": "keyword.operator.unpacking.parameter.python",
+							"match": "(\\*\\*|\\*)"
+						},
+						{
+							"include": "#lambda-nested-incomplete"
+						},
+						{
+							"include": "#illegal-names"
+						},
+						{
+							"match": "([[:alpha:]_]\\w*)\\s*(?:(,)|(?=:|$))",
+							"captures": {
+								"1": {
+									"name": "variable.parameter.function.language.python"
+								},
+								"2": {
+									"name": "punctuation.separator.parameters.python"
+								}
+							}
+						},
+						{
+							"include": "#comments"
+						},
+						{
+							"include": "#backticks"
+						},
+						{
+							"include": "#illegal-anno"
+						},
+						{
+							"include": "#lambda-parameter-with-default"
+						},
+						{
+							"include": "#line-continuation"
+						},
+						{
+							"include": "#illegal-operator"
+						}
+					]
+				}
+			]
+		},
+		"lambda-incomplete": {
+			"name": "storage.type.function.lambda.python",
+			"match": "\\blambda(?=\\s*[,)])"
+		},
+		"lambda-nested-incomplete": {
+			"name": "storage.type.function.lambda.python",
+			"match": "\\blambda(?=\\s*[:,)])"
+		},
+		"lambda-parameter-with-default": {
+			"begin": "(?x)\n  \\b\n  ([[:alpha:]_]\\w*) \\s* (=)\n",
+			"end": "(,)|(?=:|$)",
+			"beginCaptures": {
+				"1": {
+					"name": "variable.parameter.function.language.python"
+				},
+				"2": {
+					"name": "keyword.operator.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.separator.parameters.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"generator": {
+			"comment": "Match \"for ... in\" construct used in generators and for loops to\ncorrectly identify the \"in\" as a control flow keyword.\n",
+			"begin": "\\bfor\\b",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.control.flow.python"
+				}
+			},
+			"end": "\\bin\\b",
+			"endCaptures": {
+				"0": {
+					"name": "keyword.control.flow.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"function-declaration": {
+			"name": "meta.function.python",
+			"begin": "(?x)\n  \\s*\n  (?:\\b(async) \\s+)? \\b(def)\\s+\n    (?=\n      [[:alpha:]_][[:word:]]* \\s* \\(\n    )\n",
+			"end": "(:|(?=[#'\"\\n]))",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.type.function.async.python"
+				},
+				"2": {
+					"name": "storage.type.function.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.section.function.begin.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#function-def-name"
+				},
+				{
+					"include": "#parameters"
+				},
+				{
+					"include": "#line-continuation"
+				},
+				{
+					"include": "#return-annotation"
+				}
+			]
+		},
+		"function-def-name": {
+			"patterns": [
+				{
+					"include": "#illegal-object-name"
+				},
+				{
+					"include": "#builtin-possible-callables"
+				},
+				{
+					"name": "entity.name.function.python",
+					"match": "(?x)\n  \\b ([[:alpha:]_]\\w*) \\b\n"
+				}
+			]
+		},
+		"parameters": {
+			"name": "meta.function.parameters.python",
+			"begin": "(\\()",
+			"end": "(\\))",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.parameters.begin.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.parameters.end.python"
+				}
+			},
+			"patterns": [
+				{
+					"name": "keyword.operator.positional.parameter.python",
+					"match": "/"
+				},
+				{
+					"name": "keyword.operator.unpacking.parameter.python",
+					"match": "(\\*\\*|\\*)"
+				},
+				{
+					"include": "#lambda-incomplete"
+				},
+				{
+					"include": "#illegal-names"
+				},
+				{
+					"include": "#illegal-object-name"
+				},
+				{
+					"include": "#parameter-special"
+				},
+				{
+					"match": "(?x)\n  ([[:alpha:]_]\\w*)\n    \\s* (?: (,) | (?=[)#\\n=]))\n",
+					"captures": {
+						"1": {
+							"name": "variable.parameter.function.language.python"
+						},
+						"2": {
+							"name": "punctuation.separator.parameters.python"
+						}
+					}
+				},
+				{
+					"include": "#comments"
+				},
+				{
+					"include": "#loose-default"
+				},
+				{
+					"include": "#annotated-parameter"
+				}
+			]
+		},
+		"parameter-special": {
+			"match": "(?x)\n  \\b ((self)|(cls)) \\b \\s*(?:(,)|(?=\\)))\n",
+			"captures": {
+				"1": {
+					"name": "variable.parameter.function.language.python"
+				},
+				"2": {
+					"name": "variable.parameter.function.language.special.self.python"
+				},
+				"3": {
+					"name": "variable.parameter.function.language.special.cls.python"
+				},
+				"4": {
+					"name": "punctuation.separator.parameters.python"
+				}
+			}
+		},
+		"loose-default": {
+			"begin": "(=)",
+			"end": "(,)|(?=\\))",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.operator.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.separator.parameters.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"annotated-parameter": {
+			"begin": "(?x)\n  \\b\n  ([[:alpha:]_]\\w*) \\s* (:)\n",
+			"end": "(,)|(?=\\))",
+			"beginCaptures": {
+				"1": {
+					"name": "variable.parameter.function.language.python"
+				},
+				"2": {
+					"name": "punctuation.separator.annotation.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.separator.parameters.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#expression"
+				},
+				{
+					"name": "keyword.operator.assignment.python",
+					"match": "=(?!=)"
+				}
+			]
+		},
+		"return-annotation": {
+			"begin": "(->)",
+			"end": "(?=:)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.separator.annotation.result.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"item-access": {
+			"patterns": [
+				{
+					"name": "meta.item-access.python",
+					"begin": "(?x)\n  \\b(?=\n    [[:alpha:]_]\\w* \\s* \\[\n  )\n",
+					"end": "(\\])",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.arguments.end.python"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#item-name"
+						},
+						{
+							"include": "#item-index"
+						},
+						{
+							"include": "#expression"
+						}
+					]
+				}
+			]
+		},
+		"item-name": {
+			"patterns": [
+				{
+					"include": "#special-variables"
+				},
+				{
+					"include": "#builtin-functions"
+				},
+				{
+					"include": "#special-names"
+				},
+				{
+					"name": "meta.indexed-name.python",
+					"match": "(?x)\n  \\b ([[:alpha:]_]\\w*) \\b\n"
+				}
+			]
+		},
+		"item-index": {
+			"begin": "(\\[)",
+			"end": "(?=\\])",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.arguments.begin.python"
+				}
+			},
+			"contentName": "meta.item-access.arguments.python",
+			"patterns": [
+				{
+					"name": "punctuation.separator.slice.python",
+					"match": ":"
+				},
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"decorator": {
+			"name": "meta.function.decorator.python",
+			"begin": "(?x)\n  ^\\s*\n  ((@)) \\s* (?=[[:alpha:]_]\\w*)\n",
+			"end": "(?x)\n  ( \\) )\n    # trailing whitespace and comments are legal\n    (?: (.*?) (?=\\s*(?:\\#|$)) )\n  | (?=\\n|\\#)\n",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.name.function.decorator.python"
+				},
+				"2": {
+					"name": "punctuation.definition.decorator.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.arguments.end.python"
+				},
+				"2": {
+					"name": "invalid.illegal.decorator.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#decorator-name"
+				},
+				{
+					"include": "#function-arguments"
+				}
+			]
+		},
+		"decorator-name": {
+			"patterns": [
+				{
+					"include": "#builtin-callables"
+				},
+				{
+					"include": "#illegal-object-name"
+				},
+				{
+					"name": "entity.name.function.decorator.python",
+					"match": "(?x)\n  ([[:alpha:]_]\\w*) | (\\.)\n",
+					"captures": {
+						"2": {
+							"name": "punctuation.separator.period.python"
+						}
+					}
+				},
+				{
+					"include": "#line-continuation"
+				},
+				{
+					"name": "invalid.illegal.decorator.python",
+					"match": "(?x)\n  \\s* ([^([:alpha:]\\s_\\.#\\\\] .*?) (?=\\#|$)\n",
+					"captures": {
+						"1": {
+							"name": "invalid.illegal.decorator.python"
+						}
+					}
+				}
+			]
+		},
+		"call-wrapper-inheritance": {
+			"comment": "same as a function call, but in inheritance context",
+			"name": "meta.function-call.python",
+			"begin": "(?x)\n  \\b(?=\n    ([[:alpha:]_]\\w*) \\s* (\\()\n  )\n",
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.arguments.end.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#inheritance-name"
+				},
+				{
+					"include": "#function-arguments"
+				}
+			]
+		},
+		"inheritance-name": {
+			"patterns": [
+				{
+					"include": "#lambda-incomplete"
+				},
+				{
+					"include": "#builtin-possible-callables"
+				},
+				{
+					"include": "#inheritance-identifier"
+				}
+			]
+		},
+		"function-call": {
+			"name": "meta.function-call.python",
+			"comment": "Regular function call of the type \"name(args)\"",
+			"begin": "(?x)\n  \\b(?=\n    ([[:alpha:]_]\\w*) \\s* (\\()\n  )\n",
+			"end": "(\\))",
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.arguments.end.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#special-variables"
+				},
+				{
+					"include": "#function-name"
+				},
+				{
+					"include": "#function-arguments"
+				}
+			]
+		},
+		"function-name": {
+			"patterns": [
+				{
+					"include": "#builtin-possible-callables"
+				},
+				{
+					"comment": "Some color schemas support meta.function-call.generic scope",
+					"name": "meta.function-call.generic.python",
+					"match": "(?x)\n  \\b ([[:alpha:]_]\\w*) \\b\n"
+				}
+			]
+		},
+		"function-arguments": {
+			"begin": "(\\()",
+			"end": "(?=\\))(?!\\)\\s*\\()",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.arguments.begin.python"
+				}
+			},
+			"contentName": "meta.function-call.arguments.python",
+			"patterns": [
+				{
+					"name": "punctuation.separator.arguments.python",
+					"match": "(,)"
+				},
+				{
+					"match": "(?x)\n  (?:(?<=[,(])|^) \\s* (\\*{1,2})\n",
+					"captures": {
+						"1": {
+							"name": "keyword.operator.unpacking.arguments.python"
+						}
+					}
+				},
+				{
+					"include": "#lambda-incomplete"
+				},
+				{
+					"include": "#illegal-names"
+				},
+				{
+					"match": "\\b([[:alpha:]_]\\w*)\\s*(=)(?!=)",
+					"captures": {
+						"1": {
+							"name": "variable.parameter.function-call.python"
+						},
+						"2": {
+							"name": "keyword.operator.assignment.python"
+						}
+					}
+				},
+				{
+					"name": "keyword.operator.assignment.python",
+					"match": "=(?!=)"
+				},
+				{
+					"include": "#expression"
+				},
+				{
+					"match": "\\s*(\\))\\s*(\\()",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.arguments.end.python"
+						},
+						"2": {
+							"name": "punctuation.definition.arguments.begin.python"
+						}
+					}
+				}
+			]
+		},
+		"builtin-callables": {
+			"patterns": [
+				{
+					"include": "#illegal-names"
+				},
+				{
+					"include": "#illegal-object-name"
+				},
+				{
+					"include": "#builtin-exceptions"
+				},
+				{
+					"include": "#builtin-functions"
+				},
+				{
+					"include": "#builtin-types"
+				}
+			]
+		},
+		"builtin-possible-callables": {
+			"patterns": [
+				{
+					"include": "#builtin-callables"
+				},
+				{
+					"include": "#magic-names"
+				}
+			]
+		},
+		"builtin-exceptions": {
+			"name": "support.type.exception.python",
+			"match": "(?x) (?<!\\.) \\b(\n  (\n    Arithmetic | Assertion | Attribute | Buffer | BlockingIO\n    | BrokenPipe | ChildProcess\n    | (Connection (Aborted | Refused | Reset)?)\n    | EOF | Environment | FileExists | FileNotFound\n    | FloatingPoint | IO | Import | Indentation | Index | Interrupted\n    | IsADirectory | NotADirectory | Permission | ProcessLookup\n    | Timeout\n    | Key | Lookup | Memory | Name | NotImplemented | OS | Overflow\n    | Reference | Runtime | Recursion | Syntax | System\n    | Tab | Type | UnboundLocal | Unicode(Encode|Decode|Translate)?\n    | Value | Windows | ZeroDivision | ModuleNotFound\n  ) Error\n|\n  ((Pending)?Deprecation | Runtime | Syntax | User | Future | Import\n    | Unicode | Bytes | Resource\n  )? Warning\n|\n  SystemExit | Stop(Async)?Iteration\n  | KeyboardInterrupt\n  | GeneratorExit | (Base)?Exception\n)\\b\n"
+		},
+		"builtin-functions": {
+			"patterns": [
+				{
+					"name": "support.function.builtin.python",
+					"match": "(?x)\n  (?<!\\.) \\b(\n    __import__ | abs | aiter | all | any | anext | ascii | bin\n    | breakpoint | callable | chr | compile | copyright | credits\n    | delattr | dir | divmod | enumerate | eval | exec | exit\n    | filter | format | getattr | globals | hasattr | hash | help\n    | hex | id | input | isinstance | issubclass | iter | len\n    | license | locals | map | max | memoryview | min | next\n    | oct | open | ord | pow | print | quit | range | reload | repr\n    | reversed | round | setattr | sorted | sum | vars | zip\n  )\\b\n"
+				},
+				{
+					"name": "variable.legacy.builtin.python",
+					"match": "(?x)\n  (?<!\\.) \\b(\n    file | reduce | intern | raw_input | unicode | cmp | basestring\n    | execfile | long | xrange\n  )\\b\n"
+				}
+			]
+		},
+		"builtin-types": {
+			"name": "support.type.python",
+			"match": "(?x)\n  (?<!\\.) \\b(\n    bool | bytearray | bytes | classmethod | complex | dict\n    | float | frozenset | int | list | object | property\n    | set | slice | staticmethod | str | tuple | type\n\n    (?# Although 'super' is not a type, it's related to types,\n        and is special enough to be highlighted differently from\n        other built-ins)\n    | super\n  )\\b\n"
+		},
+		"magic-function-names": {
+			"comment": "these methods have magic interpretation by python and are generally called\nindirectly through syntactic constructs\n",
+			"match": "(?x)\n  \\b(\n    __(?:\n      abs | add | aenter | aexit | aiter | and | anext\n      | await | bool | call | ceil | class_getitem\n      | cmp | coerce | complex | contains | copy\n      | deepcopy | del | delattr | delete | delitem\n      | delslice | dir | div | divmod | enter | eq\n      | exit | float | floor | floordiv | format | ge\n      | get | getattr | getattribute | getinitargs\n      | getitem | getnewargs | getslice | getstate | gt\n      | hash | hex | iadd | iand | idiv | ifloordiv |\n      | ilshift | imod | imul | index | init\n      | instancecheck | int | invert | ior | ipow\n      | irshift | isub | iter | itruediv | ixor | le\n      | len | long | lshift | lt | missing | mod | mul\n      | ne | neg | new | next | nonzero | oct | or | pos\n      | pow | radd | rand | rdiv | rdivmod | reduce\n      | reduce_ex | repr | reversed | rfloordiv |\n      | rlshift | rmod | rmul | ror | round | rpow\n      | rrshift | rshift | rsub | rtruediv | rxor | set\n      | setattr | setitem | set_name | setslice\n      | setstate | sizeof | str | sub | subclasscheck\n      | truediv | trunc | unicode | xor | matmul\n      | rmatmul | imatmul | init_subclass | set_name\n      | fspath | bytes | prepare | length_hint\n    )__\n  )\\b\n",
+			"captures": {
+				"1": {
+					"name": "support.function.magic.python"
+				}
+			}
+		},
+		"magic-variable-names": {
+			"comment": "magic variables which a class/module may have.",
+			"match": "(?x)\n  \\b(\n    __(?:\n      all | annotations | bases | builtins | class\n      | closure | code | debug | defaults | dict | doc | file | func\n      | globals | kwdefaults | match_args | members | metaclass | methods\n      | module | mro | mro_entries | name | qualname | post_init | self\n      | signature | slots | subclasses | version | weakref | wrapped\n      | classcell | spec | path | package | future | traceback\n    )__\n  )\\b\n",
+			"captures": {
+				"1": {
+					"name": "support.variable.magic.python"
+				}
+			}
+		},
+		"magic-names": {
+			"patterns": [
+				{
+					"include": "#magic-function-names"
+				},
+				{
+					"include": "#magic-variable-names"
+				}
+			]
+		},
+		"illegal-names": {
+			"match": "(?x)\n  \\b(?:\n    (\n      and | assert | async | await | break | class | continue | def\n      | del | elif | else | except | finally | for | from | global\n      | if | in | is | (?<=\\.)lambda | lambda(?=\\s*[\\.=])\n      | nonlocal | not | or | pass | raise | return | try | while | with\n      | yield\n    ) | (\n      as | import\n    )\n  )\\b\n",
+			"captures": {
+				"1": {
+					"name": "keyword.control.flow.python"
+				},
+				"2": {
+					"name": "keyword.control.import.python"
+				}
+			}
+		},
+		"special-variables": {
+			"match": "(?x)\n  \\b (?<!\\.) (?:\n    (self) | (cls)\n  )\\b\n",
+			"captures": {
+				"1": {
+					"name": "variable.language.special.self.python"
+				},
+				"2": {
+					"name": "variable.language.special.cls.python"
+				}
+			}
+		},
+		"ellipsis": {
+			"name": "constant.other.ellipsis.python",
+			"match": "\\.\\.\\."
+		},
+		"backticks": {
+			"name": "invalid.deprecated.backtick.python",
+			"begin": "\\`",
+			"end": "(?:\\`|(?<!\\\\)(\\n))",
+			"patterns": [
+				{
+					"include": "#expression"
+				}
+			]
+		},
+		"illegal-operator": {
+			"patterns": [
+				{
+					"name": "invalid.illegal.operator.python",
+					"match": "&&|\\|\\||--|\\+\\+"
+				},
+				{
+					"name": "invalid.illegal.operator.python",
+					"match": "[?$]"
+				},
+				{
+					"name": "invalid.illegal.operator.python",
+					"comment": "We don't want `!` to flash when we're typing `!=`",
+					"match": "!\\b"
+				}
+			]
+		},
+		"illegal-object-name": {
+			"comment": "It's illegal to name class or function \"True\"",
+			"name": "keyword.illegal.name.python",
+			"match": "\\b(True|False|None)\\b"
+		},
+		"illegal-anno": {
+			"name": "invalid.illegal.annotation.python",
+			"match": "->"
+		},
+		"regexp-base-expression": {
+			"patterns": [
+				{
+					"include": "#regexp-quantifier"
+				},
+				{
+					"include": "#regexp-base-common"
+				}
+			]
+		},
+		"fregexp-base-expression": {
+			"patterns": [
+				{
+					"include": "#fregexp-quantifier"
+				},
+				{
+					"include": "#fstring-formatting-braces"
+				},
+				{
+					"match": "\\{.*?\\}"
+				},
+				{
+					"include": "#regexp-base-common"
+				}
+			]
+		},
+		"fstring-formatting-braces": {
+			"patterns": [
+				{
+					"comment": "empty braces are illegal",
+					"match": "({)(\\s*?)(})",
+					"captures": {
+						"1": {
+							"name": "constant.character.format.placeholder.other.python"
+						},
+						"2": {
+							"name": "invalid.illegal.brace.python"
+						},
+						"3": {
+							"name": "constant.character.format.placeholder.other.python"
+						}
+					}
+				},
+				{
+					"name": "constant.character.escape.python",
+					"match": "({{|}})"
+				}
+			]
+		},
+		"regexp-base-common": {
+			"patterns": [
+				{
+					"name": "support.other.match.any.regexp",
+					"match": "\\."
+				},
+				{
+					"name": "support.other.match.begin.regexp",
+					"match": "\\^"
+				},
+				{
+					"name": "support.other.match.end.regexp",
+					"match": "\\$"
+				},
+				{
+					"name": "keyword.operator.quantifier.regexp",
+					"match": "[+*?]\\??"
+				},
+				{
+					"name": "keyword.operator.disjunction.regexp",
+					"match": "\\|"
+				},
+				{
+					"include": "#regexp-escape-sequence"
+				}
+			]
+		},
+		"regexp-quantifier": {
+			"name": "keyword.operator.quantifier.regexp",
+			"match": "(?x)\n  \\{(\n    \\d+ | \\d+,(\\d+)? | ,\\d+\n  )\\}\n"
+		},
+		"fregexp-quantifier": {
+			"name": "keyword.operator.quantifier.regexp",
+			"match": "(?x)\n  \\{\\{(\n    \\d+ | \\d+,(\\d+)? | ,\\d+\n  )\\}\\}\n"
+		},
+		"regexp-backreference-number": {
+			"name": "meta.backreference.regexp",
+			"match": "(\\\\[1-9]\\d?)",
+			"captures": {
+				"1": {
+					"name": "entity.name.tag.backreference.regexp"
+				}
+			}
+		},
+		"regexp-backreference": {
+			"name": "meta.backreference.named.regexp",
+			"match": "(?x)\n  (\\()  (\\?P= \\w+(?:\\s+[[:alnum:]]+)?)  (\\))\n",
+			"captures": {
+				"1": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.backreference.named.begin.regexp"
+				},
+				"2": {
+					"name": "entity.name.tag.named.backreference.regexp"
+				},
+				"3": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.backreference.named.end.regexp"
+				}
+			}
+		},
+		"regexp-flags": {
+			"name": "storage.modifier.flag.regexp",
+			"match": "\\(\\?[aiLmsux]+\\)"
+		},
+		"regexp-escape-special": {
+			"name": "support.other.escape.special.regexp",
+			"match": "\\\\([AbBdDsSwWZ])"
+		},
+		"regexp-escape-character": {
+			"name": "constant.character.escape.regexp",
+			"match": "(?x)\n  \\\\ (\n        x[0-9A-Fa-f]{2}\n        | 0[0-7]{1,2}\n        | [0-7]{3}\n     )\n"
+		},
+		"regexp-escape-unicode": {
+			"name": "constant.character.unicode.regexp",
+			"match": "(?x)\n  \\\\ (\n        u[0-9A-Fa-f]{4}\n        | U[0-9A-Fa-f]{8}\n     )\n"
+		},
+		"regexp-escape-catchall": {
+			"name": "constant.character.escape.regexp",
+			"match": "\\\\(.|\\n)"
+		},
+		"regexp-escape-sequence": {
+			"patterns": [
+				{
+					"include": "#regexp-escape-special"
+				},
+				{
+					"include": "#regexp-escape-character"
+				},
+				{
+					"include": "#regexp-escape-unicode"
+				},
+				{
+					"include": "#regexp-backreference-number"
+				},
+				{
+					"include": "#regexp-escape-catchall"
+				}
+			]
+		},
+		"regexp-charecter-set-escapes": {
+			"patterns": [
+				{
+					"name": "constant.character.escape.regexp",
+					"match": "\\\\[abfnrtv\\\\]"
+				},
+				{
+					"include": "#regexp-escape-special"
+				},
+				{
+					"name": "constant.character.escape.regexp",
+					"match": "\\\\([0-7]{1,3})"
+				},
+				{
+					"include": "#regexp-escape-character"
+				},
+				{
+					"include": "#regexp-escape-unicode"
+				},
+				{
+					"include": "#regexp-escape-catchall"
+				}
+			]
+		},
+		"codetags": {
+			"match": "(?:\\b(NOTE|XXX|HACK|FIXME|BUG|TODO)\\b)",
+			"captures": {
+				"1": {
+					"name": "keyword.codetag.notation.python"
+				}
+			}
+		},
+		"comments-base": {
+			"name": "comment.line.number-sign.python",
+			"begin": "(\\#)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.comment.python"
+				}
+			},
+			"end": "($)",
+			"patterns": [
+				{
+					"include": "#codetags"
+				}
+			]
+		},
+		"comments-string-single-three": {
+			"name": "comment.line.number-sign.python",
+			"begin": "(\\#)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.comment.python"
+				}
+			},
+			"end": "($|(?='''))",
+			"patterns": [
+				{
+					"include": "#codetags"
+				}
+			]
+		},
+		"comments-string-double-three": {
+			"name": "comment.line.number-sign.python",
+			"begin": "(\\#)",
+			"beginCaptures": {
+				"1": {
+					"name": "punctuation.definition.comment.python"
+				}
+			},
+			"end": "($|(?=\"\"\"))",
+			"patterns": [
+				{
+					"include": "#codetags"
+				}
+			]
+		},
+		"single-one-regexp-expression": {
+			"patterns": [
+				{
+					"include": "#regexp-base-expression"
+				},
+				{
+					"include": "#single-one-regexp-character-set"
+				},
+				{
+					"include": "#single-one-regexp-comments"
+				},
+				{
+					"include": "#regexp-flags"
+				},
+				{
+					"include": "#single-one-regexp-named-group"
+				},
+				{
+					"include": "#regexp-backreference"
+				},
+				{
+					"include": "#single-one-regexp-lookahead"
+				},
+				{
+					"include": "#single-one-regexp-lookahead-negative"
+				},
+				{
+					"include": "#single-one-regexp-lookbehind"
+				},
+				{
+					"include": "#single-one-regexp-lookbehind-negative"
+				},
+				{
+					"include": "#single-one-regexp-conditional"
+				},
+				{
+					"include": "#single-one-regexp-parentheses-non-capturing"
+				},
+				{
+					"include": "#single-one-regexp-parentheses"
+				}
+			]
+		},
+		"single-one-regexp-character-set": {
+			"patterns": [
+				{
+					"match": "(?x)\n  \\[ \\^? \\] (?! .*?\\])\n"
+				},
+				{
+					"name": "meta.character.set.regexp",
+					"begin": "(\\[)(\\^)?(\\])?",
+					"end": "(\\]|(?=\\'))|((?=(?<!\\\\)\\n))",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.character.set.begin.regexp constant.other.set.regexp"
+						},
+						"2": {
+							"name": "keyword.operator.negation.regexp"
+						},
+						"3": {
+							"name": "constant.character.set.regexp"
+						}
+					},
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.character.set.end.regexp constant.other.set.regexp"
+						},
+						"2": {
+							"name": "invalid.illegal.newline.python"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#regexp-charecter-set-escapes"
+						},
+						{
+							"name": "constant.character.set.regexp",
+							"match": "[^\\n]"
+						}
+					]
+				}
+			]
+		},
+		"single-one-regexp-named-group": {
+			"name": "meta.named.regexp",
+			"begin": "(?x)\n  (\\()  (\\?P <\\w+(?:\\s+[[:alnum:]]+)?>)\n",
+			"end": "(\\)|(?=\\'))|((?=(?<!\\\\)\\n))",
+			"beginCaptures": {
+				"1": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.named.begin.regexp"
+				},
+				"2": {
+					"name": "entity.name.tag.named.group.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.named.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#single-one-regexp-expression"
+				}
+			]
+		},
+		"single-one-regexp-comments": {
+			"name": "comment.regexp",
+			"begin": "\\(\\?#",
+			"end": "(\\)|(?=\\'))|((?=(?<!\\\\)\\n))",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.comment.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.comment.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#codetags"
+				}
+			]
+		},
+		"single-one-regexp-lookahead": {
+			"begin": "(\\()\\?=",
+			"end": "(\\)|(?=\\'))|((?=(?<!\\\\)\\n))",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.lookahead.regexp"
+				},
+				"1": {
+					"name": "punctuation.parenthesis.lookahead.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.lookahead.regexp punctuation.parenthesis.lookahead.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#single-one-regexp-expression"
+				}
+			]
+		},
+		"single-one-regexp-lookahead-negative": {
+			"begin": "(\\()\\?!",
+			"end": "(\\)|(?=\\'))|((?=(?<!\\\\)\\n))",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.lookahead.negative.regexp"
+				},
+				"1": {
+					"name": "punctuation.parenthesis.lookahead.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.lookahead.negative.regexp punctuation.parenthesis.lookahead.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#single-one-regexp-expression"
+				}
+			]
+		},
+		"single-one-regexp-lookbehind": {
+			"begin": "(\\()\\?<=",
+			"end": "(\\)|(?=\\'))|((?=(?<!\\\\)\\n))",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.lookbehind.regexp"
+				},
+				"1": {
+					"name": "punctuation.parenthesis.lookbehind.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.lookbehind.regexp punctuation.parenthesis.lookbehind.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#single-one-regexp-expression"
+				}
+			]
+		},
+		"single-one-regexp-lookbehind-negative": {
+			"begin": "(\\()\\?<!",
+			"end": "(\\)|(?=\\'))|((?=(?<!\\\\)\\n))",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.lookbehind.negative.regexp"
+				},
+				"1": {
+					"name": "punctuation.parenthesis.lookbehind.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.lookbehind.negative.regexp punctuation.parenthesis.lookbehind.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#single-one-regexp-expression"
+				}
+			]
+		},
+		"single-one-regexp-conditional": {
+			"begin": "(\\()\\?\\((\\w+(?:\\s+[[:alnum:]]+)?|\\d+)\\)",
+			"end": "(\\)|(?=\\'))|((?=(?<!\\\\)\\n))",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.conditional.regexp"
+				},
+				"1": {
+					"name": "punctuation.parenthesis.conditional.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.conditional.negative.regexp punctuation.parenthesis.conditional.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#single-one-regexp-expression"
+				}
+			]
+		},
+		"single-one-regexp-parentheses-non-capturing": {
+			"begin": "\\(\\?:",
+			"end": "(\\)|(?=\\'))|((?=(?<!\\\\)\\n))",
+			"beginCaptures": {
+				"0": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.non-capturing.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.non-capturing.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#single-one-regexp-expression"
+				}
+			]
+		},
+		"single-one-regexp-parentheses": {
+			"begin": "\\(",
+			"end": "(\\)|(?=\\'))|((?=(?<!\\\\)\\n))",
+			"beginCaptures": {
+				"0": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#single-one-regexp-expression"
+				}
+			]
+		},
+		"single-three-regexp-expression": {
+			"patterns": [
+				{
+					"include": "#regexp-base-expression"
+				},
+				{
+					"include": "#single-three-regexp-character-set"
+				},
+				{
+					"include": "#single-three-regexp-comments"
+				},
+				{
+					"include": "#regexp-flags"
+				},
+				{
+					"include": "#single-three-regexp-named-group"
+				},
+				{
+					"include": "#regexp-backreference"
+				},
+				{
+					"include": "#single-three-regexp-lookahead"
+				},
+				{
+					"include": "#single-three-regexp-lookahead-negative"
+				},
+				{
+					"include": "#single-three-regexp-lookbehind"
+				},
+				{
+					"include": "#single-three-regexp-lookbehind-negative"
+				},
+				{
+					"include": "#single-three-regexp-conditional"
+				},
+				{
+					"include": "#single-three-regexp-parentheses-non-capturing"
+				},
+				{
+					"include": "#single-three-regexp-parentheses"
+				},
+				{
+					"include": "#comments-string-single-three"
+				}
+			]
+		},
+		"single-three-regexp-character-set": {
+			"patterns": [
+				{
+					"match": "(?x)\n  \\[ \\^? \\] (?! .*?\\])\n"
+				},
+				{
+					"name": "meta.character.set.regexp",
+					"begin": "(\\[)(\\^)?(\\])?",
+					"end": "(\\]|(?=\\'\\'\\'))",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.character.set.begin.regexp constant.other.set.regexp"
+						},
+						"2": {
+							"name": "keyword.operator.negation.regexp"
+						},
+						"3": {
+							"name": "constant.character.set.regexp"
+						}
+					},
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.character.set.end.regexp constant.other.set.regexp"
+						},
+						"2": {
+							"name": "invalid.illegal.newline.python"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#regexp-charecter-set-escapes"
+						},
+						{
+							"name": "constant.character.set.regexp",
+							"match": "[^\\n]"
+						}
+					]
+				}
+			]
+		},
+		"single-three-regexp-named-group": {
+			"name": "meta.named.regexp",
+			"begin": "(?x)\n  (\\()  (\\?P <\\w+(?:\\s+[[:alnum:]]+)?>)\n",
+			"end": "(\\)|(?=\\'\\'\\'))",
+			"beginCaptures": {
+				"1": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.named.begin.regexp"
+				},
+				"2": {
+					"name": "entity.name.tag.named.group.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.named.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#single-three-regexp-expression"
+				},
+				{
+					"include": "#comments-string-single-three"
+				}
+			]
+		},
+		"single-three-regexp-comments": {
+			"name": "comment.regexp",
+			"begin": "\\(\\?#",
+			"end": "(\\)|(?=\\'\\'\\'))",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.comment.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.comment.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#codetags"
+				}
+			]
+		},
+		"single-three-regexp-lookahead": {
+			"begin": "(\\()\\?=",
+			"end": "(\\)|(?=\\'\\'\\'))",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.lookahead.regexp"
+				},
+				"1": {
+					"name": "punctuation.parenthesis.lookahead.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.lookahead.regexp punctuation.parenthesis.lookahead.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#single-three-regexp-expression"
+				},
+				{
+					"include": "#comments-string-single-three"
+				}
+			]
+		},
+		"single-three-regexp-lookahead-negative": {
+			"begin": "(\\()\\?!",
+			"end": "(\\)|(?=\\'\\'\\'))",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.lookahead.negative.regexp"
+				},
+				"1": {
+					"name": "punctuation.parenthesis.lookahead.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.lookahead.negative.regexp punctuation.parenthesis.lookahead.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#single-three-regexp-expression"
+				},
+				{
+					"include": "#comments-string-single-three"
+				}
+			]
+		},
+		"single-three-regexp-lookbehind": {
+			"begin": "(\\()\\?<=",
+			"end": "(\\)|(?=\\'\\'\\'))",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.lookbehind.regexp"
+				},
+				"1": {
+					"name": "punctuation.parenthesis.lookbehind.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.lookbehind.regexp punctuation.parenthesis.lookbehind.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#single-three-regexp-expression"
+				},
+				{
+					"include": "#comments-string-single-three"
+				}
+			]
+		},
+		"single-three-regexp-lookbehind-negative": {
+			"begin": "(\\()\\?<!",
+			"end": "(\\)|(?=\\'\\'\\'))",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.lookbehind.negative.regexp"
+				},
+				"1": {
+					"name": "punctuation.parenthesis.lookbehind.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.lookbehind.negative.regexp punctuation.parenthesis.lookbehind.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#single-three-regexp-expression"
+				},
+				{
+					"include": "#comments-string-single-three"
+				}
+			]
+		},
+		"single-three-regexp-conditional": {
+			"begin": "(\\()\\?\\((\\w+(?:\\s+[[:alnum:]]+)?|\\d+)\\)",
+			"end": "(\\)|(?=\\'\\'\\'))",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.conditional.regexp"
+				},
+				"1": {
+					"name": "punctuation.parenthesis.conditional.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.conditional.negative.regexp punctuation.parenthesis.conditional.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#single-three-regexp-expression"
+				},
+				{
+					"include": "#comments-string-single-three"
+				}
+			]
+		},
+		"single-three-regexp-parentheses-non-capturing": {
+			"begin": "\\(\\?:",
+			"end": "(\\)|(?=\\'\\'\\'))",
+			"beginCaptures": {
+				"0": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.non-capturing.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.non-capturing.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#single-three-regexp-expression"
+				},
+				{
+					"include": "#comments-string-single-three"
+				}
+			]
+		},
+		"single-three-regexp-parentheses": {
+			"begin": "\\(",
+			"end": "(\\)|(?=\\'\\'\\'))",
+			"beginCaptures": {
+				"0": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#single-three-regexp-expression"
+				},
+				{
+					"include": "#comments-string-single-three"
+				}
+			]
+		},
+		"double-one-regexp-expression": {
+			"patterns": [
+				{
+					"include": "#regexp-base-expression"
+				},
+				{
+					"include": "#double-one-regexp-character-set"
+				},
+				{
+					"include": "#double-one-regexp-comments"
+				},
+				{
+					"include": "#regexp-flags"
+				},
+				{
+					"include": "#double-one-regexp-named-group"
+				},
+				{
+					"include": "#regexp-backreference"
+				},
+				{
+					"include": "#double-one-regexp-lookahead"
+				},
+				{
+					"include": "#double-one-regexp-lookahead-negative"
+				},
+				{
+					"include": "#double-one-regexp-lookbehind"
+				},
+				{
+					"include": "#double-one-regexp-lookbehind-negative"
+				},
+				{
+					"include": "#double-one-regexp-conditional"
+				},
+				{
+					"include": "#double-one-regexp-parentheses-non-capturing"
+				},
+				{
+					"include": "#double-one-regexp-parentheses"
+				}
+			]
+		},
+		"double-one-regexp-character-set": {
+			"patterns": [
+				{
+					"match": "(?x)\n  \\[ \\^? \\] (?! .*?\\])\n"
+				},
+				{
+					"name": "meta.character.set.regexp",
+					"begin": "(\\[)(\\^)?(\\])?",
+					"end": "(\\]|(?=\"))|((?=(?<!\\\\)\\n))",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.character.set.begin.regexp constant.other.set.regexp"
+						},
+						"2": {
+							"name": "keyword.operator.negation.regexp"
+						},
+						"3": {
+							"name": "constant.character.set.regexp"
+						}
+					},
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.character.set.end.regexp constant.other.set.regexp"
+						},
+						"2": {
+							"name": "invalid.illegal.newline.python"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#regexp-charecter-set-escapes"
+						},
+						{
+							"name": "constant.character.set.regexp",
+							"match": "[^\\n]"
+						}
+					]
+				}
+			]
+		},
+		"double-one-regexp-named-group": {
+			"name": "meta.named.regexp",
+			"begin": "(?x)\n  (\\()  (\\?P <\\w+(?:\\s+[[:alnum:]]+)?>)\n",
+			"end": "(\\)|(?=\"))|((?=(?<!\\\\)\\n))",
+			"beginCaptures": {
+				"1": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.named.begin.regexp"
+				},
+				"2": {
+					"name": "entity.name.tag.named.group.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.named.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#double-one-regexp-expression"
+				}
+			]
+		},
+		"double-one-regexp-comments": {
+			"name": "comment.regexp",
+			"begin": "\\(\\?#",
+			"end": "(\\)|(?=\"))|((?=(?<!\\\\)\\n))",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.comment.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.comment.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#codetags"
+				}
+			]
+		},
+		"double-one-regexp-lookahead": {
+			"begin": "(\\()\\?=",
+			"end": "(\\)|(?=\"))|((?=(?<!\\\\)\\n))",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.lookahead.regexp"
+				},
+				"1": {
+					"name": "punctuation.parenthesis.lookahead.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.lookahead.regexp punctuation.parenthesis.lookahead.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#double-one-regexp-expression"
+				}
+			]
+		},
+		"double-one-regexp-lookahead-negative": {
+			"begin": "(\\()\\?!",
+			"end": "(\\)|(?=\"))|((?=(?<!\\\\)\\n))",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.lookahead.negative.regexp"
+				},
+				"1": {
+					"name": "punctuation.parenthesis.lookahead.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.lookahead.negative.regexp punctuation.parenthesis.lookahead.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#double-one-regexp-expression"
+				}
+			]
+		},
+		"double-one-regexp-lookbehind": {
+			"begin": "(\\()\\?<=",
+			"end": "(\\)|(?=\"))|((?=(?<!\\\\)\\n))",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.lookbehind.regexp"
+				},
+				"1": {
+					"name": "punctuation.parenthesis.lookbehind.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.lookbehind.regexp punctuation.parenthesis.lookbehind.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#double-one-regexp-expression"
+				}
+			]
+		},
+		"double-one-regexp-lookbehind-negative": {
+			"begin": "(\\()\\?<!",
+			"end": "(\\)|(?=\"))|((?=(?<!\\\\)\\n))",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.lookbehind.negative.regexp"
+				},
+				"1": {
+					"name": "punctuation.parenthesis.lookbehind.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.lookbehind.negative.regexp punctuation.parenthesis.lookbehind.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#double-one-regexp-expression"
+				}
+			]
+		},
+		"double-one-regexp-conditional": {
+			"begin": "(\\()\\?\\((\\w+(?:\\s+[[:alnum:]]+)?|\\d+)\\)",
+			"end": "(\\)|(?=\"))|((?=(?<!\\\\)\\n))",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.conditional.regexp"
+				},
+				"1": {
+					"name": "punctuation.parenthesis.conditional.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.conditional.negative.regexp punctuation.parenthesis.conditional.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#double-one-regexp-expression"
+				}
+			]
+		},
+		"double-one-regexp-parentheses-non-capturing": {
+			"begin": "\\(\\?:",
+			"end": "(\\)|(?=\"))|((?=(?<!\\\\)\\n))",
+			"beginCaptures": {
+				"0": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.non-capturing.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.non-capturing.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#double-one-regexp-expression"
+				}
+			]
+		},
+		"double-one-regexp-parentheses": {
+			"begin": "\\(",
+			"end": "(\\)|(?=\"))|((?=(?<!\\\\)\\n))",
+			"beginCaptures": {
+				"0": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#double-one-regexp-expression"
+				}
+			]
+		},
+		"double-three-regexp-expression": {
+			"patterns": [
+				{
+					"include": "#regexp-base-expression"
+				},
+				{
+					"include": "#double-three-regexp-character-set"
+				},
+				{
+					"include": "#double-three-regexp-comments"
+				},
+				{
+					"include": "#regexp-flags"
+				},
+				{
+					"include": "#double-three-regexp-named-group"
+				},
+				{
+					"include": "#regexp-backreference"
+				},
+				{
+					"include": "#double-three-regexp-lookahead"
+				},
+				{
+					"include": "#double-three-regexp-lookahead-negative"
+				},
+				{
+					"include": "#double-three-regexp-lookbehind"
+				},
+				{
+					"include": "#double-three-regexp-lookbehind-negative"
+				},
+				{
+					"include": "#double-three-regexp-conditional"
+				},
+				{
+					"include": "#double-three-regexp-parentheses-non-capturing"
+				},
+				{
+					"include": "#double-three-regexp-parentheses"
+				},
+				{
+					"include": "#comments-string-double-three"
+				}
+			]
+		},
+		"double-three-regexp-character-set": {
+			"patterns": [
+				{
+					"match": "(?x)\n  \\[ \\^? \\] (?! .*?\\])\n"
+				},
+				{
+					"name": "meta.character.set.regexp",
+					"begin": "(\\[)(\\^)?(\\])?",
+					"end": "(\\]|(?=\"\"\"))",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.character.set.begin.regexp constant.other.set.regexp"
+						},
+						"2": {
+							"name": "keyword.operator.negation.regexp"
+						},
+						"3": {
+							"name": "constant.character.set.regexp"
+						}
+					},
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.character.set.end.regexp constant.other.set.regexp"
+						},
+						"2": {
+							"name": "invalid.illegal.newline.python"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#regexp-charecter-set-escapes"
+						},
+						{
+							"name": "constant.character.set.regexp",
+							"match": "[^\\n]"
+						}
+					]
+				}
+			]
+		},
+		"double-three-regexp-named-group": {
+			"name": "meta.named.regexp",
+			"begin": "(?x)\n  (\\()  (\\?P <\\w+(?:\\s+[[:alnum:]]+)?>)\n",
+			"end": "(\\)|(?=\"\"\"))",
+			"beginCaptures": {
+				"1": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.named.begin.regexp"
+				},
+				"2": {
+					"name": "entity.name.tag.named.group.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.named.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#double-three-regexp-expression"
+				},
+				{
+					"include": "#comments-string-double-three"
+				}
+			]
+		},
+		"double-three-regexp-comments": {
+			"name": "comment.regexp",
+			"begin": "\\(\\?#",
+			"end": "(\\)|(?=\"\"\"))",
+			"beginCaptures": {
+				"0": {
+					"name": "punctuation.comment.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.comment.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#codetags"
+				}
+			]
+		},
+		"double-three-regexp-lookahead": {
+			"begin": "(\\()\\?=",
+			"end": "(\\)|(?=\"\"\"))",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.lookahead.regexp"
+				},
+				"1": {
+					"name": "punctuation.parenthesis.lookahead.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.lookahead.regexp punctuation.parenthesis.lookahead.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#double-three-regexp-expression"
+				},
+				{
+					"include": "#comments-string-double-three"
+				}
+			]
+		},
+		"double-three-regexp-lookahead-negative": {
+			"begin": "(\\()\\?!",
+			"end": "(\\)|(?=\"\"\"))",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.lookahead.negative.regexp"
+				},
+				"1": {
+					"name": "punctuation.parenthesis.lookahead.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.lookahead.negative.regexp punctuation.parenthesis.lookahead.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#double-three-regexp-expression"
+				},
+				{
+					"include": "#comments-string-double-three"
+				}
+			]
+		},
+		"double-three-regexp-lookbehind": {
+			"begin": "(\\()\\?<=",
+			"end": "(\\)|(?=\"\"\"))",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.lookbehind.regexp"
+				},
+				"1": {
+					"name": "punctuation.parenthesis.lookbehind.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.lookbehind.regexp punctuation.parenthesis.lookbehind.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#double-three-regexp-expression"
+				},
+				{
+					"include": "#comments-string-double-three"
+				}
+			]
+		},
+		"double-three-regexp-lookbehind-negative": {
+			"begin": "(\\()\\?<!",
+			"end": "(\\)|(?=\"\"\"))",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.lookbehind.negative.regexp"
+				},
+				"1": {
+					"name": "punctuation.parenthesis.lookbehind.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.lookbehind.negative.regexp punctuation.parenthesis.lookbehind.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#double-three-regexp-expression"
+				},
+				{
+					"include": "#comments-string-double-three"
+				}
+			]
+		},
+		"double-three-regexp-conditional": {
+			"begin": "(\\()\\?\\((\\w+(?:\\s+[[:alnum:]]+)?|\\d+)\\)",
+			"end": "(\\)|(?=\"\"\"))",
+			"beginCaptures": {
+				"0": {
+					"name": "keyword.operator.conditional.regexp"
+				},
+				"1": {
+					"name": "punctuation.parenthesis.conditional.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "keyword.operator.conditional.negative.regexp punctuation.parenthesis.conditional.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#double-three-regexp-expression"
+				},
+				{
+					"include": "#comments-string-double-three"
+				}
+			]
+		},
+		"double-three-regexp-parentheses-non-capturing": {
+			"begin": "\\(\\?:",
+			"end": "(\\)|(?=\"\"\"))",
+			"beginCaptures": {
+				"0": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.non-capturing.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.non-capturing.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#double-three-regexp-expression"
+				},
+				{
+					"include": "#comments-string-double-three"
+				}
+			]
+		},
+		"double-three-regexp-parentheses": {
+			"begin": "\\(",
+			"end": "(\\)|(?=\"\"\"))",
+			"beginCaptures": {
+				"0": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.begin.regexp"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "support.other.parenthesis.regexp punctuation.parenthesis.end.regexp"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#double-three-regexp-expression"
+				},
+				{
+					"include": "#comments-string-double-three"
+				}
+			]
+		},
+		"regexp-single-one-line": {
+			"name": "string.regexp.quoted.single.python",
+			"begin": "\\b(([uU]r)|([bB]r)|(r[bB]?))(\\')",
+			"end": "(\\')|(?<!\\\\)(\\n)",
+			"beginCaptures": {
+				"2": {
+					"name": "invalid.deprecated.prefix.python"
+				},
+				"3": {
+					"name": "storage.type.string.python"
+				},
+				"4": {
+					"name": "storage.type.string.python"
+				},
+				"5": {
+					"name": "punctuation.definition.string.begin.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#single-one-regexp-expression"
+				}
+			]
+		},
+		"regexp-single-three-line": {
+			"name": "string.regexp.quoted.multi.python",
+			"begin": "\\b(([uU]r)|([bB]r)|(r[bB]?))(\\'\\'\\')",
+			"end": "(\\'\\'\\')",
+			"beginCaptures": {
+				"2": {
+					"name": "invalid.deprecated.prefix.python"
+				},
+				"3": {
+					"name": "storage.type.string.python"
+				},
+				"4": {
+					"name": "storage.type.string.python"
+				},
+				"5": {
+					"name": "punctuation.definition.string.begin.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#single-three-regexp-expression"
+				}
+			]
+		},
+		"regexp-double-one-line": {
+			"name": "string.regexp.quoted.single.python",
+			"begin": "\\b(([uU]r)|([bB]r)|(r[bB]?))(\")",
+			"end": "(\")|(?<!\\\\)(\\n)",
+			"beginCaptures": {
+				"2": {
+					"name": "invalid.deprecated.prefix.python"
+				},
+				"3": {
+					"name": "storage.type.string.python"
+				},
+				"4": {
+					"name": "storage.type.string.python"
+				},
+				"5": {
+					"name": "punctuation.definition.string.begin.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#double-one-regexp-expression"
+				}
+			]
+		},
+		"regexp-double-three-line": {
+			"name": "string.regexp.quoted.multi.python",
+			"begin": "\\b(([uU]r)|([bB]r)|(r[bB]?))(\"\"\")",
+			"end": "(\"\"\")",
+			"beginCaptures": {
+				"2": {
+					"name": "invalid.deprecated.prefix.python"
+				},
+				"3": {
+					"name": "storage.type.string.python"
+				},
+				"4": {
+					"name": "storage.type.string.python"
+				},
+				"5": {
+					"name": "punctuation.definition.string.begin.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#double-three-regexp-expression"
+				}
+			]
+		},
+		"string-raw-quoted-single-line": {
+			"name": "string.quoted.raw.single.python",
+			"begin": "\\b(([uU]R)|(R))((['\"]))",
+			"end": "(\\4)|((?<!\\\\)\\n)",
+			"beginCaptures": {
+				"2": {
+					"name": "invalid.deprecated.prefix.python"
+				},
+				"3": {
+					"name": "storage.type.string.python"
+				},
+				"4": {
+					"name": "punctuation.definition.string.begin.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#string-single-bad-brace1-formatting-raw"
+				},
+				{
+					"include": "#string-single-bad-brace2-formatting-raw"
+				},
+				{
+					"include": "#string-raw-guts"
+				}
+			]
+		},
+		"string-bin-quoted-single-line": {
+			"name": "string.quoted.binary.single.python",
+			"begin": "(\\b[bB])((['\"]))",
+			"end": "(\\2)|((?<!\\\\)\\n)",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.type.string.python"
+				},
+				"2": {
+					"name": "punctuation.definition.string.begin.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#string-entity"
+				}
+			]
+		},
+		"string-raw-bin-quoted-single-line": {
+			"name": "string.quoted.raw.binary.single.python",
+			"begin": "(\\b(?:R[bB]|[bB]R))((['\"]))",
+			"end": "(\\2)|((?<!\\\\)\\n)",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.type.string.python"
+				},
+				"2": {
+					"name": "punctuation.definition.string.begin.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#string-raw-bin-guts"
+				}
+			]
+		},
+		"string-quoted-single-line": {
+			"name": "string.quoted.single.python",
+			"begin": "(?:\\b([rR])(?=[uU]))?([uU])?((['\"]))",
+			"end": "(\\3)|((?<!\\\\)\\n)",
+			"beginCaptures": {
+				"1": {
+					"name": "invalid.illegal.prefix.python"
+				},
+				"2": {
+					"name": "storage.type.string.python"
+				},
+				"3": {
+					"name": "punctuation.definition.string.begin.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#string-single-bad-brace1-formatting-unicode"
+				},
+				{
+					"include": "#string-single-bad-brace2-formatting-unicode"
+				},
+				{
+					"include": "#string-unicode-guts"
+				}
+			]
+		},
+		"string-single-bad-brace1-formatting-unicode": {
+			"comment": "template using {% ... %}",
+			"begin": "(?x)\n    (?= \\{%\n          ( .*? (?!(['\"])|((?<!\\\\)\\n)) )\n        %\\}\n    )\n",
+			"end": "(?=(['\"])|((?<!\\\\)\\n))",
+			"patterns": [
+				{
+					"include": "#escape-sequence-unicode"
+				},
+				{
+					"include": "#escape-sequence"
+				},
+				{
+					"include": "#string-line-continuation"
+				}
+			]
+		},
+		"string-single-bad-brace1-formatting-raw": {
+			"comment": "template using {% ... %}",
+			"begin": "(?x)\n    (?= \\{%\n          ( .*? (?!(['\"])|((?<!\\\\)\\n)) )\n        %\\}\n    )\n",
+			"end": "(?=(['\"])|((?<!\\\\)\\n))",
+			"patterns": [
+				{
+					"include": "#string-consume-escape"
+				}
+			]
+		},
+		"string-single-bad-brace2-formatting-unicode": {
+			"comment": "odd format or format-like syntax",
+			"begin": "(?x)\n    (?!\\{\\{)\n    (?= \\{ (\n              \\w*? (?!(['\"])|((?<!\\\\)\\n)) [^!:\\.\\[}\\w]\n           )\n        .*?(?!(['\"])|((?<!\\\\)\\n))\n        \\}\n    )\n",
+			"end": "(?=(['\"])|((?<!\\\\)\\n))",
+			"patterns": [
+				{
+					"include": "#escape-sequence-unicode"
+				},
+				{
+					"include": "#string-entity"
+				}
+			]
+		},
+		"string-single-bad-brace2-formatting-raw": {
+			"comment": "odd format or format-like syntax",
+			"begin": "(?x)\n    (?!\\{\\{)\n    (?= \\{ (\n              \\w*? (?!(['\"])|((?<!\\\\)\\n)) [^!:\\.\\[}\\w]\n           )\n        .*?(?!(['\"])|((?<!\\\\)\\n))\n        \\}\n    )\n",
+			"end": "(?=(['\"])|((?<!\\\\)\\n))",
+			"patterns": [
+				{
+					"include": "#string-consume-escape"
+				},
+				{
+					"include": "#string-formatting"
+				}
+			]
+		},
+		"string-raw-quoted-multi-line": {
+			"name": "string.quoted.raw.multi.python",
+			"begin": "\\b(([uU]R)|(R))('''|\"\"\")",
+			"end": "(\\4)",
+			"beginCaptures": {
+				"2": {
+					"name": "invalid.deprecated.prefix.python"
+				},
+				"3": {
+					"name": "storage.type.string.python"
+				},
+				"4": {
+					"name": "punctuation.definition.string.begin.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#string-multi-bad-brace1-formatting-raw"
+				},
+				{
+					"include": "#string-multi-bad-brace2-formatting-raw"
+				},
+				{
+					"include": "#string-raw-guts"
+				}
+			]
+		},
+		"string-bin-quoted-multi-line": {
+			"name": "string.quoted.binary.multi.python",
+			"begin": "(\\b[bB])('''|\"\"\")",
+			"end": "(\\2)",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.type.string.python"
+				},
+				"2": {
+					"name": "punctuation.definition.string.begin.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#string-entity"
+				}
+			]
+		},
+		"string-raw-bin-quoted-multi-line": {
+			"name": "string.quoted.raw.binary.multi.python",
+			"begin": "(\\b(?:R[bB]|[bB]R))('''|\"\"\")",
+			"end": "(\\2)",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.type.string.python"
+				},
+				"2": {
+					"name": "punctuation.definition.string.begin.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#string-raw-bin-guts"
+				}
+			]
+		},
+		"string-quoted-multi-line": {
+			"name": "string.quoted.multi.python",
+			"begin": "(?:\\b([rR])(?=[uU]))?([uU])?('''|\"\"\")",
+			"end": "(\\3)",
+			"beginCaptures": {
+				"1": {
+					"name": "invalid.illegal.prefix.python"
+				},
+				"2": {
+					"name": "storage.type.string.python"
+				},
+				"3": {
+					"name": "punctuation.definition.string.begin.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#string-multi-bad-brace1-formatting-unicode"
+				},
+				{
+					"include": "#string-multi-bad-brace2-formatting-unicode"
+				},
+				{
+					"include": "#string-unicode-guts"
+				}
+			]
+		},
+		"string-multi-bad-brace1-formatting-unicode": {
+			"comment": "template using {% ... %}",
+			"begin": "(?x)\n    (?= \\{%\n          ( .*? (?!'''|\"\"\") )\n        %\\}\n    )\n",
+			"end": "(?='''|\"\"\")",
+			"patterns": [
+				{
+					"include": "#escape-sequence-unicode"
+				},
+				{
+					"include": "#escape-sequence"
+				},
+				{
+					"include": "#string-line-continuation"
+				}
+			]
+		},
+		"string-multi-bad-brace1-formatting-raw": {
+			"comment": "template using {% ... %}",
+			"begin": "(?x)\n    (?= \\{%\n          ( .*? (?!'''|\"\"\") )\n        %\\}\n    )\n",
+			"end": "(?='''|\"\"\")",
+			"patterns": [
+				{
+					"include": "#string-consume-escape"
+				}
+			]
+		},
+		"string-multi-bad-brace2-formatting-unicode": {
+			"comment": "odd format or format-like syntax",
+			"begin": "(?x)\n    (?!\\{\\{)\n    (?= \\{ (\n              \\w*? (?!'''|\"\"\") [^!:\\.\\[}\\w]\n           )\n        .*?(?!'''|\"\"\")\n        \\}\n    )\n",
+			"end": "(?='''|\"\"\")",
+			"patterns": [
+				{
+					"include": "#escape-sequence-unicode"
+				},
+				{
+					"include": "#string-entity"
+				}
+			]
+		},
+		"string-multi-bad-brace2-formatting-raw": {
+			"comment": "odd format or format-like syntax",
+			"begin": "(?x)\n    (?!\\{\\{)\n    (?= \\{ (\n              \\w*? (?!'''|\"\"\") [^!:\\.\\[}\\w]\n           )\n        .*?(?!'''|\"\"\")\n        \\}\n    )\n",
+			"end": "(?='''|\"\"\")",
+			"patterns": [
+				{
+					"include": "#string-consume-escape"
+				},
+				{
+					"include": "#string-formatting"
+				}
+			]
+		},
+		"fstring-fnorm-quoted-single-line": {
+			"name": "meta.fstring.python",
+			"begin": "(\\b[fF])([bBuU])?((['\"]))",
+			"end": "(\\3)|((?<!\\\\)\\n)",
+			"beginCaptures": {
+				"1": {
+					"name": "string.interpolated.python string.quoted.single.python storage.type.string.python"
+				},
+				"2": {
+					"name": "invalid.illegal.prefix.python"
+				},
+				"3": {
+					"name": "punctuation.definition.string.begin.python string.interpolated.python string.quoted.single.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python string.interpolated.python string.quoted.single.python"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#fstring-guts"
+				},
+				{
+					"include": "#fstring-illegal-single-brace"
+				},
+				{
+					"include": "#fstring-single-brace"
+				},
+				{
+					"include": "#fstring-single-core"
+				}
+			]
+		},
+		"fstring-normf-quoted-single-line": {
+			"name": "meta.fstring.python",
+			"begin": "(\\b[bBuU])([fF])((['\"]))",
+			"end": "(\\3)|((?<!\\\\)\\n)",
+			"beginCaptures": {
+				"1": {
+					"name": "invalid.illegal.prefix.python"
+				},
+				"2": {
+					"name": "string.interpolated.python string.quoted.single.python storage.type.string.python"
+				},
+				"3": {
+					"name": "punctuation.definition.string.begin.python string.quoted.single.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python string.interpolated.python string.quoted.single.python"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#fstring-guts"
+				},
+				{
+					"include": "#fstring-illegal-single-brace"
+				},
+				{
+					"include": "#fstring-single-brace"
+				},
+				{
+					"include": "#fstring-single-core"
+				}
+			]
+		},
+		"fstring-raw-quoted-single-line": {
+			"name": "meta.fstring.python",
+			"begin": "(\\b(?:[rR][fF]|[fF][rR]))((['\"]))",
+			"end": "(\\2)|((?<!\\\\)\\n)",
+			"beginCaptures": {
+				"1": {
+					"name": "string.interpolated.python string.quoted.raw.single.python storage.type.string.python"
+				},
+				"2": {
+					"name": "punctuation.definition.string.begin.python string.quoted.raw.single.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python string.interpolated.python string.quoted.raw.single.python"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#fstring-raw-guts"
+				},
+				{
+					"include": "#fstring-illegal-single-brace"
+				},
+				{
+					"include": "#fstring-single-brace"
+				},
+				{
+					"include": "#fstring-raw-single-core"
+				}
+			]
+		},
+		"fstring-single-core": {
+			"name": "string.interpolated.python string.quoted.single.python",
+			"match": "(?x)\n  (.+?)\n    (\n      (?# .* and .*? in multi-line match need special handling of\n        newlines otherwise SublimeText and Atom will match slightly\n        differently.\n\n        The guard for newlines has to be separate from the\n        lookahead because of special $ matching rule.)\n      ($\\n?)\n      |\n      (?=[\\\\\\}\\{]|(['\"])|((?<!\\\\)\\n))\n    )\n  (?# due to how multiline regexps are matched we need a special case\n    for matching a newline character)\n  | \\n\n"
+		},
+		"fstring-raw-single-core": {
+			"name": "string.interpolated.python string.quoted.raw.single.python",
+			"match": "(?x)\n  (.+?)\n    (\n      (?# .* and .*? in multi-line match need special handling of\n        newlines otherwise SublimeText and Atom will match slightly\n        differently.\n\n        The guard for newlines has to be separate from the\n        lookahead because of special $ matching rule.)\n      ($\\n?)\n      |\n      (?=[\\\\\\}\\{]|(['\"])|((?<!\\\\)\\n))\n    )\n  (?# due to how multiline regexps are matched we need a special case\n    for matching a newline character)\n  | \\n\n"
+		},
+		"fstring-single-brace": {
+			"comment": "value interpolation using { ... }",
+			"begin": "(\\{)",
+			"end": "(?x)\n  (\\})|(?=\\n)\n",
+			"beginCaptures": {
+				"1": {
+					"name": "constant.character.format.placeholder.other.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "constant.character.format.placeholder.other.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#fstring-terminator-single"
+				},
+				{
+					"include": "#f-expression"
+				}
+			]
+		},
+		"fstring-terminator-single": {
+			"patterns": [
+				{
+					"name": "storage.type.format.python",
+					"match": "(=(![rsa])?)(?=})"
+				},
+				{
+					"name": "storage.type.format.python",
+					"match": "(=?![rsa])(?=})"
+				},
+				{
+					"match": "(?x)\n  ( (?: =?) (?: ![rsa])? )\n    ( : \\w? [<>=^]? [-+ ]? \\#?\n      \\d* ,? (\\.\\d+)? [bcdeEfFgGnosxX%]? )(?=})\n",
+					"captures": {
+						"1": {
+							"name": "storage.type.format.python"
+						},
+						"2": {
+							"name": "storage.type.format.python"
+						}
+					}
+				},
+				{
+					"include": "#fstring-terminator-single-tail"
+				}
+			]
+		},
+		"fstring-terminator-single-tail": {
+			"begin": "((?:=?)(?:![rsa])?)(:)(?=.*?{)",
+			"end": "(?=})|(?=\\n)",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.type.format.python"
+				},
+				"2": {
+					"name": "storage.type.format.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#fstring-illegal-single-brace"
+				},
+				{
+					"include": "#fstring-single-brace"
+				},
+				{
+					"name": "storage.type.format.python",
+					"match": "([bcdeEfFgGnosxX%])(?=})"
+				},
+				{
+					"name": "storage.type.format.python",
+					"match": "(\\.\\d+)"
+				},
+				{
+					"name": "storage.type.format.python",
+					"match": "(,)"
+				},
+				{
+					"name": "storage.type.format.python",
+					"match": "(\\d+)"
+				},
+				{
+					"name": "storage.type.format.python",
+					"match": "(\\#)"
+				},
+				{
+					"name": "storage.type.format.python",
+					"match": "([-+ ])"
+				},
+				{
+					"name": "storage.type.format.python",
+					"match": "([<>=^])"
+				},
+				{
+					"name": "storage.type.format.python",
+					"match": "(\\w)"
+				}
+			]
+		},
+		"fstring-fnorm-quoted-multi-line": {
+			"name": "meta.fstring.python",
+			"begin": "(\\b[fF])([bBuU])?('''|\"\"\")",
+			"end": "(\\3)",
+			"beginCaptures": {
+				"1": {
+					"name": "string.interpolated.python string.quoted.multi.python storage.type.string.python"
+				},
+				"2": {
+					"name": "invalid.illegal.prefix.python"
+				},
+				"3": {
+					"name": "punctuation.definition.string.begin.python string.interpolated.python string.quoted.multi.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python string.interpolated.python string.quoted.multi.python"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#fstring-guts"
+				},
+				{
+					"include": "#fstring-illegal-multi-brace"
+				},
+				{
+					"include": "#fstring-multi-brace"
+				},
+				{
+					"include": "#fstring-multi-core"
+				}
+			]
+		},
+		"fstring-normf-quoted-multi-line": {
+			"name": "meta.fstring.python",
+			"begin": "(\\b[bBuU])([fF])('''|\"\"\")",
+			"end": "(\\3)",
+			"beginCaptures": {
+				"1": {
+					"name": "invalid.illegal.prefix.python"
+				},
+				"2": {
+					"name": "string.interpolated.python string.quoted.multi.python storage.type.string.python"
+				},
+				"3": {
+					"name": "punctuation.definition.string.begin.python string.quoted.multi.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python string.interpolated.python string.quoted.multi.python"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#fstring-guts"
+				},
+				{
+					"include": "#fstring-illegal-multi-brace"
+				},
+				{
+					"include": "#fstring-multi-brace"
+				},
+				{
+					"include": "#fstring-multi-core"
+				}
+			]
+		},
+		"fstring-raw-quoted-multi-line": {
+			"name": "meta.fstring.python",
+			"begin": "(\\b(?:[rR][fF]|[fF][rR]))('''|\"\"\")",
+			"end": "(\\2)",
+			"beginCaptures": {
+				"1": {
+					"name": "string.interpolated.python string.quoted.raw.multi.python storage.type.string.python"
+				},
+				"2": {
+					"name": "punctuation.definition.string.begin.python string.quoted.raw.multi.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "punctuation.definition.string.end.python string.interpolated.python string.quoted.raw.multi.python"
+				},
+				"2": {
+					"name": "invalid.illegal.newline.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#fstring-raw-guts"
+				},
+				{
+					"include": "#fstring-illegal-multi-brace"
+				},
+				{
+					"include": "#fstring-multi-brace"
+				},
+				{
+					"include": "#fstring-raw-multi-core"
+				}
+			]
+		},
+		"fstring-multi-core": {
+			"name": "string.interpolated.python string.quoted.multi.python",
+			"match": "(?x)\n  (.+?)\n    (\n      (?# .* and .*? in multi-line match need special handling of\n        newlines otherwise SublimeText and Atom will match slightly\n        differently.\n\n        The guard for newlines has to be separate from the\n        lookahead because of special $ matching rule.)\n      ($\\n?)\n      |\n      (?=[\\\\\\}\\{]|'''|\"\"\")\n    )\n  (?# due to how multiline regexps are matched we need a special case\n    for matching a newline character)\n  | \\n\n"
+		},
+		"fstring-raw-multi-core": {
+			"name": "string.interpolated.python string.quoted.raw.multi.python",
+			"match": "(?x)\n  (.+?)\n    (\n      (?# .* and .*? in multi-line match need special handling of\n        newlines otherwise SublimeText and Atom will match slightly\n        differently.\n\n        The guard for newlines has to be separate from the\n        lookahead because of special $ matching rule.)\n      ($\\n?)\n      |\n      (?=[\\\\\\}\\{]|'''|\"\"\")\n    )\n  (?# due to how multiline regexps are matched we need a special case\n    for matching a newline character)\n  | \\n\n"
+		},
+		"fstring-multi-brace": {
+			"comment": "value interpolation using { ... }",
+			"begin": "(\\{)",
+			"end": "(?x)\n  (\\})\n",
+			"beginCaptures": {
+				"1": {
+					"name": "constant.character.format.placeholder.other.python"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "constant.character.format.placeholder.other.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#fstring-terminator-multi"
+				},
+				{
+					"include": "#f-expression"
+				}
+			]
+		},
+		"fstring-terminator-multi": {
+			"patterns": [
+				{
+					"name": "storage.type.format.python",
+					"match": "(=(![rsa])?)(?=})"
+				},
+				{
+					"name": "storage.type.format.python",
+					"match": "(=?![rsa])(?=})"
+				},
+				{
+					"match": "(?x)\n  ( (?: =?) (?: ![rsa])? )\n    ( : \\w? [<>=^]? [-+ ]? \\#?\n      \\d* ,? (\\.\\d+)? [bcdeEfFgGnosxX%]? )(?=})\n",
+					"captures": {
+						"1": {
+							"name": "storage.type.format.python"
+						},
+						"2": {
+							"name": "storage.type.format.python"
+						}
+					}
+				},
+				{
+					"include": "#fstring-terminator-multi-tail"
+				}
+			]
+		},
+		"fstring-terminator-multi-tail": {
+			"begin": "((?:=?)(?:![rsa])?)(:)(?=.*?{)",
+			"end": "(?=})",
+			"beginCaptures": {
+				"1": {
+					"name": "storage.type.format.python"
+				},
+				"2": {
+					"name": "storage.type.format.python"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#fstring-illegal-multi-brace"
+				},
+				{
+					"include": "#fstring-multi-brace"
+				},
+				{
+					"name": "storage.type.format.python",
+					"match": "([bcdeEfFgGnosxX%])(?=})"
+				},
+				{
+					"name": "storage.type.format.python",
+					"match": "(\\.\\d+)"
+				},
+				{
+					"name": "storage.type.format.python",
+					"match": "(,)"
+				},
+				{
+					"name": "storage.type.format.python",
+					"match": "(\\d+)"
+				},
+				{
+					"name": "storage.type.format.python",
+					"match": "(\\#)"
+				},
+				{
+					"name": "storage.type.format.python",
+					"match": "([-+ ])"
+				},
+				{
+					"name": "storage.type.format.python",
+					"match": "([<>=^])"
+				},
+				{
+					"name": "storage.type.format.python",
+					"match": "(\\w)"
+				}
+			]
+		}
+	}
+}

--- a/microbenchmark/src/androidTest/assets/themes/dark_plus.json
+++ b/microbenchmark/src/androidTest/assets/themes/dark_plus.json
@@ -1,0 +1,205 @@
+{
+	"$schema": "vscode://schemas/color-theme",
+	"name": "Dark+",
+	"include": "./dark_vs.json",
+	"tokenColors": [
+		{
+			"name": "Function declarations",
+			"scope": [
+				"entity.name.function",
+				"support.function",
+				"support.constant.handlebars",
+				"source.powershell variable.other.member",
+				"entity.name.operator.custom-literal"
+			],
+			"settings": {
+				"foreground": "#DCDCAA"
+			}
+		},
+		{
+			"name": "Types declaration and references",
+			"scope": [
+				"support.class",
+				"support.type",
+				"entity.name.type",
+				"entity.name.namespace",
+				"entity.other.attribute",
+				"entity.name.scope-resolution",
+				"entity.name.class",
+				"storage.type.numeric.go",
+				"storage.type.byte.go",
+				"storage.type.boolean.go",
+				"storage.type.string.go",
+				"storage.type.uintptr.go",
+				"storage.type.error.go",
+				"storage.type.rune.go",
+				"storage.type.cs",
+				"storage.type.generic.cs",
+				"storage.type.modifier.cs",
+				"storage.type.variable.cs",
+				"storage.type.annotation.java",
+				"storage.type.generic.java",
+				"storage.type.java",
+				"storage.type.object.array.java",
+				"storage.type.primitive.array.java",
+				"storage.type.primitive.java",
+				"storage.type.token.java",
+				"storage.type.groovy",
+				"storage.type.annotation.groovy",
+				"storage.type.parameters.groovy",
+				"storage.type.generic.groovy",
+				"storage.type.object.array.groovy",
+				"storage.type.primitive.array.groovy",
+				"storage.type.primitive.groovy"
+			],
+			"settings": {
+				"foreground": "#4EC9B0"
+			}
+		},
+		{
+			"name": "Types declaration and references, TS grammar specific",
+			"scope": [
+				"meta.type.cast.expr",
+				"meta.type.new.expr",
+				"support.constant.math",
+				"support.constant.dom",
+				"support.constant.json",
+				"entity.other.inherited-class",
+				"punctuation.separator.namespace.ruby"
+			],
+			"settings": {
+				"foreground": "#4EC9B0"
+			}
+		},
+		{
+			"name": "Control flow / Special keywords",
+			"scope": [
+				"keyword.control",
+				"source.cpp keyword.operator.new",
+				"keyword.operator.delete",
+				"keyword.other.using",
+				"keyword.other.directive.using",
+				"keyword.other.operator",
+				"entity.name.operator"
+			],
+			"settings": {
+				"foreground": "#C586C0"
+			}
+		},
+		{
+			"name": "Variable and parameter name",
+			"scope": [
+				"variable",
+				"meta.definition.variable.name",
+				"support.variable",
+				"entity.name.variable",
+				"constant.other.placeholder"
+			],
+			"settings": {
+				"foreground": "#9CDCFE"
+			}
+		},
+		{
+			"name": "Constants and enums",
+			"scope": [
+				"variable.other.constant",
+				"variable.other.enummember"
+			],
+			"settings": {
+				"foreground": "#4FC1FF"
+			}
+		},
+		{
+			"name": "Object keys, TS grammar specific",
+			"scope": [
+				"meta.object-literal.key"
+			],
+			"settings": {
+				"foreground": "#9CDCFE"
+			}
+		},
+		{
+			"name": "CSS property value",
+			"scope": [
+				"support.constant.property-value",
+				"support.constant.font-name",
+				"support.constant.media-type",
+				"support.constant.media",
+				"constant.other.color.rgb-value",
+				"constant.other.rgb-value",
+				"support.constant.color"
+			],
+			"settings": {
+				"foreground": "#CE9178"
+			}
+		},
+		{
+			"name": "Regular expression groups",
+			"scope": [
+				"punctuation.definition.group.regexp",
+				"punctuation.definition.group.assertion.regexp",
+				"punctuation.definition.character-class.regexp",
+				"punctuation.character.set.begin.regexp",
+				"punctuation.character.set.end.regexp",
+				"keyword.operator.negation.regexp",
+				"support.other.parenthesis.regexp"
+			],
+			"settings": {
+				"foreground": "#CE9178"
+			}
+		},
+		{
+			"scope": [
+				"constant.character.character-class.regexp",
+				"constant.other.character-class.set.regexp",
+				"constant.other.character-class.regexp",
+				"constant.character.set.regexp"
+			],
+			"settings": {
+				"foreground": "#d16969"
+			}
+		},
+		{
+			"scope": [
+				"keyword.operator.or.regexp",
+				"keyword.control.anchor.regexp"
+			],
+			"settings": {
+				"foreground": "#DCDCAA"
+			}
+		},
+		{
+			"scope": "keyword.operator.quantifier.regexp",
+			"settings": {
+				"foreground": "#d7ba7d"
+			}
+		},
+		{
+			"scope": [
+				"constant.character",
+				"constant.other.option"
+			],
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "constant.character.escape",
+			"settings": {
+				"foreground": "#d7ba7d"
+			}
+		},
+		{
+			"scope": "entity.name.label",
+			"settings": {
+				"foreground": "#C8C8C8"
+			}
+		}
+	],
+	"semanticTokenColors": {
+		"newOperator":"#C586C0",
+		"stringLiteral":"#ce9178",
+		"customLiteral": "#DCDCAA",
+		"numberLiteral": "#b5cea8"
+	}
+}

--- a/microbenchmark/src/androidTest/assets/themes/dark_vs.json
+++ b/microbenchmark/src/androidTest/assets/themes/dark_vs.json
@@ -1,0 +1,411 @@
+{
+	"$schema": "vscode://schemas/color-theme",
+	"name": "Dark (Visual Studio)",
+	"colors": {
+		"checkbox.border": "#6B6B6B",
+		"editor.background": "#1E1E1E",
+		"editor.foreground": "#D4D4D4",
+		"editor.inactiveSelectionBackground": "#3A3D41",
+		"editorIndentGuide.background1": "#404040",
+		"editorIndentGuide.activeBackground1": "#707070",
+		"editor.selectionHighlightBackground": "#ADD6FF26",
+		"list.dropBackground": "#383B3D",
+		"activityBarBadge.background": "#007ACC",
+		"sideBarTitle.foreground": "#BBBBBB",
+		"input.placeholderForeground": "#A6A6A6",
+		"menu.background": "#252526",
+		"menu.foreground": "#CCCCCC",
+		"menu.separatorBackground": "#454545",
+		"menu.border": "#454545",
+		"menu.selectionBackground": "#0078d4",
+		"statusBarItem.remoteForeground": "#FFF",
+		"statusBarItem.remoteBackground": "#16825D",
+		"ports.iconRunningProcessForeground": "#369432",
+		"sideBarSectionHeader.background": "#0000",
+		"sideBarSectionHeader.border": "#ccc3",
+		"tab.selectedBackground": "#222222",
+		"tab.selectedForeground": "#ffffffa0",
+		"tab.lastPinnedBorder": "#ccc3",
+		"list.activeSelectionIconForeground": "#FFF",
+		"terminal.inactiveSelectionBackground": "#3A3D41",
+		"widget.border": "#303031",
+		"actionBar.toggledBackground": "#383a49"
+	},
+	"tokenColors": [
+		{
+			"scope": [
+				"meta.embedded",
+				"source.groovy.embedded",
+				"string meta.image.inline.markdown",
+				"variable.legacy.builtin.python"
+			],
+			"settings": {
+				"foreground": "#D4D4D4"
+			}
+		},
+		{
+			"scope": "emphasis",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"scope": "strong",
+			"settings": {
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"scope": "header",
+			"settings": {
+				"foreground": "#000080"
+			}
+		},
+		{
+			"scope": "comment",
+			"settings": {
+				"foreground": "#6A9955"
+			}
+		},
+		{
+			"scope": "constant.language",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": [
+				"constant.numeric",
+				"variable.other.enummember",
+				"keyword.operator.plus.exponent",
+				"keyword.operator.minus.exponent"
+			],
+			"settings": {
+				"foreground": "#b5cea8"
+			}
+		},
+		{
+			"scope": "constant.regexp",
+			"settings": {
+				"foreground": "#646695"
+			}
+		},
+		{
+			"scope": "entity.name.tag",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": [
+				"entity.name.tag.css",
+				"entity.name.tag.less"
+			],
+			"settings": {
+				"foreground": "#d7ba7d"
+			}
+		},
+		{
+			"scope": "entity.other.attribute-name",
+			"settings": {
+				"foreground": "#9cdcfe"
+			}
+		},
+		{
+			"scope": [
+				"entity.other.attribute-name.class.css",
+				"source.css entity.other.attribute-name.class",
+				"entity.other.attribute-name.id.css",
+				"entity.other.attribute-name.parent-selector.css",
+				"entity.other.attribute-name.parent.less",
+				"source.css entity.other.attribute-name.pseudo-class",
+				"entity.other.attribute-name.pseudo-element.css",
+				"source.css.less entity.other.attribute-name.id",
+				"entity.other.attribute-name.scss"
+			],
+			"settings": {
+				"foreground": "#d7ba7d"
+			}
+		},
+		{
+			"scope": "invalid",
+			"settings": {
+				"foreground": "#f44747"
+			}
+		},
+		{
+			"scope": "markup.underline",
+			"settings": {
+				"fontStyle": "underline"
+			}
+		},
+		{
+			"scope": "markup.bold",
+			"settings": {
+				"fontStyle": "bold",
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "markup.heading",
+			"settings": {
+				"fontStyle": "bold",
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "markup.italic",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"scope": "markup.strikethrough",
+			"settings": {
+				"fontStyle": "strikethrough"
+			}
+		},
+		{
+			"scope": "markup.inserted",
+			"settings": {
+				"foreground": "#b5cea8"
+			}
+		},
+		{
+			"scope": "markup.deleted",
+			"settings": {
+				"foreground": "#ce9178"
+			}
+		},
+		{
+			"scope": "markup.changed",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "punctuation.definition.quote.begin.markdown",
+			"settings": {
+				"foreground": "#6A9955"
+			}
+		},
+		{
+			"scope": "punctuation.definition.list.begin.markdown",
+			"settings": {
+				"foreground": "#6796e6"
+			}
+		},
+		{
+			"scope": "markup.inline.raw",
+			"settings": {
+				"foreground": "#ce9178"
+			}
+		},
+		{
+			"name": "brackets of XML/HTML tags",
+			"scope": "punctuation.definition.tag",
+			"settings": {
+				"foreground": "#808080"
+			}
+		},
+		{
+			"scope": [
+				"meta.preprocessor",
+				"entity.name.function.preprocessor"
+			],
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "meta.preprocessor.string",
+			"settings": {
+				"foreground": "#ce9178"
+			}
+		},
+		{
+			"scope": "meta.preprocessor.numeric",
+			"settings": {
+				"foreground": "#b5cea8"
+			}
+		},
+		{
+			"scope": "meta.structure.dictionary.key.python",
+			"settings": {
+				"foreground": "#9cdcfe"
+			}
+		},
+		{
+			"scope": "meta.diff.header",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "storage",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "storage.type",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": [
+				"storage.modifier",
+				"keyword.operator.noexcept"
+			],
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": [
+				"string",
+				"meta.embedded.assembly"
+			],
+			"settings": {
+				"foreground": "#ce9178"
+			}
+		},
+		{
+			"scope": "string.tag",
+			"settings": {
+				"foreground": "#ce9178"
+			}
+		},
+		{
+			"scope": "string.value",
+			"settings": {
+				"foreground": "#ce9178"
+			}
+		},
+		{
+			"scope": "string.regexp",
+			"settings": {
+				"foreground": "#d16969"
+			}
+		},
+		{
+			"name": "String interpolation",
+			"scope": [
+				"punctuation.definition.template-expression.begin",
+				"punctuation.definition.template-expression.end",
+				"punctuation.section.embedded"
+			],
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"name": "Reset JavaScript string interpolation expression",
+			"scope": [
+				"meta.template.expression"
+			],
+			"settings": {
+				"foreground": "#d4d4d4"
+			}
+		},
+		{
+			"scope": [
+				"support.type.vendored.property-name",
+				"support.type.property-name",
+				"source.css variable",
+				"source.coffee.embedded"
+			],
+			"settings": {
+				"foreground": "#9cdcfe"
+			}
+		},
+		{
+			"scope": "keyword",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "keyword.control",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "keyword.operator",
+			"settings": {
+				"foreground": "#d4d4d4"
+			}
+		},
+		{
+			"scope": [
+				"keyword.operator.new",
+				"keyword.operator.expression",
+				"keyword.operator.cast",
+				"keyword.operator.sizeof",
+				"keyword.operator.alignof",
+				"keyword.operator.typeid",
+				"keyword.operator.alignas",
+				"keyword.operator.instanceof",
+				"keyword.operator.logical.python",
+				"keyword.operator.wordlike"
+			],
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "keyword.other.unit",
+			"settings": {
+				"foreground": "#b5cea8"
+			}
+		},
+		{
+			"scope": [
+				"punctuation.section.embedded.begin.php",
+				"punctuation.section.embedded.end.php"
+			],
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		},
+		{
+			"scope": "support.function.git-rebase",
+			"settings": {
+				"foreground": "#9cdcfe"
+			}
+		},
+		{
+			"scope": "constant.sha.git-rebase",
+			"settings": {
+				"foreground": "#b5cea8"
+			}
+		},
+		{
+			"name": "coloring of the Java import and package identifiers",
+			"scope": [
+				"storage.modifier.import.java",
+				"variable.language.wildcard.java",
+				"storage.modifier.package.java"
+			],
+			"settings": {
+				"foreground": "#d4d4d4"
+			}
+		},
+		{
+			"name": "this.self",
+			"scope": "variable.language",
+			"settings": {
+				"foreground": "#569cd6"
+			}
+		}
+	],
+	"semanticHighlighting": true,
+	"semanticTokenColors": {
+		"newOperator": "#d4d4d4",
+		"stringLiteral": "#ce9178",
+		"customLiteral": "#D4D4D4",
+		"numberLiteral": "#b5cea8"
+	}
+}

--- a/microbenchmark/src/androidTest/assets/themes/light_plus.json
+++ b/microbenchmark/src/androidTest/assets/themes/light_plus.json
@@ -1,0 +1,207 @@
+{
+	"$schema": "vscode://schemas/color-theme",
+	"name": "Light+",
+	"include": "./light_vs.json",
+	"tokenColors": [
+		{
+			"name": "Function declarations",
+			"scope": [
+				"entity.name.function",
+				"support.function",
+				"support.constant.handlebars",
+				"source.powershell variable.other.member",
+				"entity.name.operator.custom-literal"
+			],
+			"settings": {
+				"foreground": "#795E26"
+			}
+		},
+		{
+			"name": "Types declaration and references",
+			"scope": [
+				"support.class",
+				"support.type",
+				"entity.name.type",
+				"entity.name.namespace",
+				"entity.other.attribute",
+				"entity.name.scope-resolution",
+				"entity.name.class",
+				"storage.type.numeric.go",
+				"storage.type.byte.go",
+				"storage.type.boolean.go",
+				"storage.type.string.go",
+				"storage.type.uintptr.go",
+				"storage.type.error.go",
+				"storage.type.rune.go",
+				"storage.type.cs",
+				"storage.type.generic.cs",
+				"storage.type.modifier.cs",
+				"storage.type.variable.cs",
+				"storage.type.annotation.java",
+				"storage.type.generic.java",
+				"storage.type.java",
+				"storage.type.object.array.java",
+				"storage.type.primitive.array.java",
+				"storage.type.primitive.java",
+				"storage.type.token.java",
+				"storage.type.groovy",
+				"storage.type.annotation.groovy",
+				"storage.type.parameters.groovy",
+				"storage.type.generic.groovy",
+				"storage.type.object.array.groovy",
+				"storage.type.primitive.array.groovy",
+				"storage.type.primitive.groovy"
+			],
+			"settings": {
+				"foreground": "#267f99"
+			}
+		},
+		{
+			"name": "Types declaration and references, TS grammar specific",
+			"scope": [
+				"meta.type.cast.expr",
+				"meta.type.new.expr",
+				"support.constant.math",
+				"support.constant.dom",
+				"support.constant.json",
+				"entity.other.inherited-class",
+				"punctuation.separator.namespace.ruby"
+			],
+			"settings": {
+				"foreground": "#267f99"
+			}
+		},
+		{
+			"name": "Control flow / Special keywords",
+			"scope": [
+				"keyword.control",
+				"source.cpp keyword.operator.new",
+				"source.cpp keyword.operator.delete",
+				"keyword.other.using",
+				"keyword.other.directive.using",
+				"keyword.other.operator",
+				"entity.name.operator"
+			],
+			"settings": {
+				"foreground": "#AF00DB"
+			}
+		},
+		{
+			"name": "Variable and parameter name",
+			"scope": [
+				"variable",
+				"meta.definition.variable.name",
+				"support.variable",
+				"entity.name.variable",
+				"constant.other.placeholder"
+
+			],
+			"settings": {
+				"foreground": "#001080"
+			}
+		},
+		{
+			"name": "Constants and enums",
+			"scope": [
+				"variable.other.constant",
+				"variable.other.enummember"
+			],
+			"settings": {
+				"foreground": "#0070C1"
+			}
+		},
+		{
+			"name": "Object keys, TS grammar specific",
+			"scope": [
+				"meta.object-literal.key"
+			],
+			"settings": {
+				"foreground": "#001080"
+			}
+		},
+		{
+			"name": "CSS property value",
+			"scope": [
+				"support.constant.property-value",
+				"support.constant.font-name",
+				"support.constant.media-type",
+				"support.constant.media",
+				"constant.other.color.rgb-value",
+				"constant.other.rgb-value",
+				"support.constant.color"
+			],
+			"settings": {
+				"foreground": "#0451a5"
+			}
+		},
+		{
+			"name": "Regular expression groups",
+			"scope": [
+				"punctuation.definition.group.regexp",
+				"punctuation.definition.group.assertion.regexp",
+				"punctuation.definition.character-class.regexp",
+				"punctuation.character.set.begin.regexp",
+				"punctuation.character.set.end.regexp",
+				"keyword.operator.negation.regexp",
+				"support.other.parenthesis.regexp"
+			],
+			"settings": {
+				"foreground": "#d16969"
+			}
+		},
+		{
+			"scope": [
+				"constant.character.character-class.regexp",
+				"constant.other.character-class.set.regexp",
+				"constant.other.character-class.regexp",
+				"constant.character.set.regexp"
+			],
+			"settings": {
+				"foreground": "#811f3f"
+			}
+		},
+		{
+			"scope": "keyword.operator.quantifier.regexp",
+			"settings": {
+				"foreground": "#000000"
+			}
+		},
+		{
+			"scope": [
+				"keyword.operator.or.regexp",
+				"keyword.control.anchor.regexp"
+			],
+			"settings": {
+				"foreground": "#EE0000"
+			}
+		},
+		{
+			"scope": [
+				"constant.character",
+				"constant.other.option"
+			],
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"scope": "constant.character.escape",
+			"settings": {
+				"foreground": "#EE0000"
+			}
+		},
+		{
+			"scope": "entity.name.label",
+			"settings": {
+				"foreground": "#000000"
+			}
+		}
+	],
+	"semanticHighlighting": true,
+	"semanticTokenColors": {
+		"newOperator": "#AF00DB",
+		"stringLiteral": "#a31515",
+		"customLiteral": "#795E26",
+		"numberLiteral": "#098658"
+	}
+}

--- a/microbenchmark/src/androidTest/assets/themes/light_vs.json
+++ b/microbenchmark/src/androidTest/assets/themes/light_vs.json
@@ -1,0 +1,437 @@
+{
+	"$schema": "vscode://schemas/color-theme",
+	"name": "Light (Visual Studio)",
+	"colors": {
+		"checkbox.border": "#919191",
+		"editor.background": "#FFFFFF",
+		"editor.foreground": "#000000",
+		"editor.inactiveSelectionBackground": "#E5EBF1",
+		"editorIndentGuide.background1": "#D3D3D3",
+		"editorIndentGuide.activeBackground1": "#939393",
+		"editor.selectionHighlightBackground": "#ADD6FF80",
+		"editorSuggestWidget.background": "#F3F3F3",
+		"activityBarBadge.background": "#007ACC",
+		"sideBarTitle.foreground": "#6F6F6F",
+		"list.hoverBackground": "#E8E8E8",
+		"menu.border": "#D4D4D4",
+		"input.placeholderForeground": "#767676",
+		"searchEditor.textInputBorder": "#CECECE",
+		"settings.textInputBorder": "#CECECE",
+		"settings.numberInputBorder": "#CECECE",
+		"statusBarItem.remoteForeground": "#FFF",
+		"statusBarItem.remoteBackground": "#16825D",
+		"ports.iconRunningProcessForeground": "#369432",
+		"sideBarSectionHeader.background": "#0000",
+		"sideBarSectionHeader.border": "#61616130",
+		"tab.selectedForeground": "#333333b3",
+		"tab.selectedBackground": "#ffffffa5",
+		"tab.lastPinnedBorder": "#61616130",
+		"notebook.cellBorderColor": "#E8E8E8",
+		"notebook.selectedCellBackground": "#c8ddf150",
+		"statusBarItem.errorBackground": "#c72e0f",
+		"list.activeSelectionIconForeground": "#FFF",
+		"list.focusAndSelectionOutline": "#90C2F9",
+		"terminal.inactiveSelectionBackground": "#E5EBF1",
+		"widget.border": "#d4d4d4",
+		"actionBar.toggledBackground": "#dddddd",
+		"diffEditor.unchangedRegionBackground": "#f8f8f8"
+	},
+	"tokenColors": [
+		{
+			"scope": [
+				"meta.embedded",
+				"source.groovy.embedded",
+				"string meta.image.inline.markdown",
+				"variable.legacy.builtin.python"
+			],
+			"settings": {
+				"foreground": "#000000ff"
+			}
+		},
+		{
+			"scope": "emphasis",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"scope": "strong",
+			"settings": {
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"scope": "meta.diff.header",
+			"settings": {
+				"foreground": "#000080"
+			}
+		},
+		{
+			"scope": "comment",
+			"settings": {
+				"foreground": "#008000"
+			}
+		},
+		{
+			"scope": "constant.language",
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"scope": [
+				"constant.numeric",
+				"variable.other.enummember",
+				"keyword.operator.plus.exponent",
+				"keyword.operator.minus.exponent"
+			],
+			"settings": {
+				"foreground": "#098658"
+			}
+		},
+		{
+			"scope": "constant.regexp",
+			"settings": {
+				"foreground": "#811f3f"
+			}
+		},
+		{
+			"name": "css tags in selectors, xml tags",
+			"scope": "entity.name.tag",
+			"settings": {
+				"foreground": "#800000"
+			}
+		},
+		{
+			"scope": "entity.name.selector",
+			"settings": {
+				"foreground": "#800000"
+			}
+		},
+		{
+			"scope": "entity.other.attribute-name",
+			"settings": {
+				"foreground": "#e50000"
+			}
+		},
+		{
+			"scope": [
+				"entity.other.attribute-name.class.css",
+				"source.css entity.other.attribute-name.class",
+				"entity.other.attribute-name.id.css",
+				"entity.other.attribute-name.parent-selector.css",
+				"entity.other.attribute-name.parent.less",
+				"source.css entity.other.attribute-name.pseudo-class",
+				"entity.other.attribute-name.pseudo-element.css",
+				"source.css.less entity.other.attribute-name.id",
+				"entity.other.attribute-name.scss"
+			],
+			"settings": {
+				"foreground": "#800000"
+			}
+		},
+		{
+			"scope": "invalid",
+			"settings": {
+				"foreground": "#cd3131"
+			}
+		},
+		{
+			"scope": "markup.underline",
+			"settings": {
+				"fontStyle": "underline"
+			}
+		},
+		{
+			"scope": "markup.bold",
+			"settings": {
+				"fontStyle": "bold",
+				"foreground": "#000080"
+			}
+		},
+		{
+			"scope": "markup.heading",
+			"settings": {
+				"fontStyle": "bold",
+				"foreground": "#800000"
+			}
+		},
+		{
+			"scope": "markup.italic",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"scope": "markup.strikethrough",
+			"settings": {
+				"fontStyle": "strikethrough"
+			}
+		},
+		{
+			"scope": "markup.inserted",
+			"settings": {
+				"foreground": "#098658"
+			}
+		},
+		{
+			"scope": "markup.deleted",
+			"settings": {
+				"foreground": "#a31515"
+			}
+		},
+		{
+			"scope": "markup.changed",
+			"settings": {
+				"foreground": "#0451a5"
+			}
+		},
+		{
+			"scope": [
+				"punctuation.definition.quote.begin.markdown",
+				"punctuation.definition.list.begin.markdown"
+			],
+			"settings": {
+				"foreground": "#0451a5"
+			}
+		},
+		{
+			"scope": "markup.inline.raw",
+			"settings": {
+				"foreground": "#800000"
+			}
+		},
+		{
+			"name": "brackets of XML/HTML tags",
+			"scope": "punctuation.definition.tag",
+			"settings": {
+				"foreground": "#800000"
+			}
+		},
+		{
+			"scope": [
+				"meta.preprocessor",
+				"entity.name.function.preprocessor"
+			],
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"scope": "meta.preprocessor.string",
+			"settings": {
+				"foreground": "#a31515"
+			}
+		},
+		{
+			"scope": "meta.preprocessor.numeric",
+			"settings": {
+				"foreground": "#098658"
+			}
+		},
+		{
+			"scope": "meta.structure.dictionary.key.python",
+			"settings": {
+				"foreground": "#0451a5"
+			}
+		},
+		{
+			"scope": "storage",
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"scope": "storage.type",
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"scope": [
+				"storage.modifier",
+				"keyword.operator.noexcept"
+			],
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"scope": [
+				"string",
+				"meta.embedded.assembly"
+			],
+			"settings": {
+				"foreground": "#a31515"
+			}
+		},
+		{
+			"scope": [
+				"string.comment.buffered.block.pug",
+				"string.quoted.pug",
+				"string.interpolated.pug",
+				"string.unquoted.plain.in.yaml",
+				"string.unquoted.plain.out.yaml",
+				"string.unquoted.block.yaml",
+				"string.quoted.single.yaml",
+				"string.quoted.double.xml",
+				"string.quoted.single.xml",
+				"string.unquoted.cdata.xml",
+				"string.quoted.double.html",
+				"string.quoted.single.html",
+				"string.unquoted.html",
+				"string.quoted.single.handlebars",
+				"string.quoted.double.handlebars"
+			],
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"scope": "string.regexp",
+			"settings": {
+				"foreground": "#811f3f"
+			}
+		},
+		{
+			"name": "String interpolation",
+			"scope": [
+				"punctuation.definition.template-expression.begin",
+				"punctuation.definition.template-expression.end",
+				"punctuation.section.embedded"
+			],
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"name": "Reset JavaScript string interpolation expression",
+			"scope": [
+				"meta.template.expression"
+			],
+			"settings": {
+				"foreground": "#000000"
+			}
+		},
+		{
+			"scope": [
+				"support.constant.property-value",
+				"support.constant.font-name",
+				"support.constant.media-type",
+				"support.constant.media",
+				"constant.other.color.rgb-value",
+				"constant.other.rgb-value",
+				"support.constant.color"
+			],
+			"settings": {
+				"foreground": "#0451a5"
+			}
+		},
+		{
+			"scope": [
+				"support.type.vendored.property-name",
+				"support.type.property-name",
+				"source.css variable",
+				"source.coffee.embedded"
+			],
+			"settings": {
+				"foreground": "#e50000"
+			}
+		},
+		{
+			"scope": [
+				"support.type.property-name.json"
+			],
+			"settings": {
+				"foreground": "#0451a5"
+			}
+		},
+		{
+			"scope": "keyword",
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"scope": "keyword.control",
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"scope": "keyword.operator",
+			"settings": {
+				"foreground": "#000000"
+			}
+		},
+		{
+			"scope": [
+				"keyword.operator.new",
+				"keyword.operator.expression",
+				"keyword.operator.cast",
+				"keyword.operator.sizeof",
+				"keyword.operator.alignof",
+				"keyword.operator.typeid",
+				"keyword.operator.alignas",
+				"keyword.operator.instanceof",
+				"keyword.operator.logical.python",
+				"keyword.operator.wordlike"
+			],
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		},
+		{
+			"scope": "keyword.other.unit",
+			"settings": {
+				"foreground": "#098658"
+			}
+		},
+		{
+			"scope": [
+				"punctuation.section.embedded.begin.php",
+				"punctuation.section.embedded.end.php"
+			],
+			"settings": {
+				"foreground": "#800000"
+			}
+		},
+		{
+			"scope": "support.function.git-rebase",
+			"settings": {
+				"foreground": "#0451a5"
+			}
+		},
+		{
+			"scope": "constant.sha.git-rebase",
+			"settings": {
+				"foreground": "#098658"
+			}
+		},
+		{
+			"name": "coloring of the Java import and package identifiers",
+			"scope": [
+				"storage.modifier.import.java",
+				"variable.language.wildcard.java",
+				"storage.modifier.package.java"
+			],
+			"settings": {
+				"foreground": "#000000"
+			}
+		},
+		{
+			"name": "this.self",
+			"scope": "variable.language",
+			"settings": {
+				"foreground": "#0000ff"
+			}
+		}
+	],
+	"semanticHighlighting": true,
+	"semanticTokenColors": {
+		"newOperator": "#0000ff",
+		"stringLiteral": "#a31515",
+		"customLiteral": "#000000",
+		"numberLiteral": "#098658"
+	}
+}

--- a/microbenchmark/src/androidTest/assets/themes/monokai.json
+++ b/microbenchmark/src/androidTest/assets/themes/monokai.json
@@ -1,0 +1,492 @@
+
+
+
+
+
+
+{
+	"type": "dark",
+	"colors": {
+		"dropdown.background": "#414339",
+		"list.activeSelectionBackground": "#75715E",
+		"quickInputList.focusBackground": "#414339",
+		"dropdown.listBackground": "#1e1f1c",
+		"list.inactiveSelectionBackground": "#414339",
+		"list.hoverBackground": "#3e3d32",
+		"list.dropBackground": "#414339",
+		"list.highlightForeground": "#f8f8f2",
+		"button.background": "#75715E",
+		"editor.background": "#272822",
+		"editor.foreground": "#f8f8f2",
+		"selection.background": "#878b9180",
+		"editor.selectionHighlightBackground": "#575b6180",
+		"editor.selectionBackground": "#878b9180",
+		"minimap.selectionHighlight": "#878b9180",
+		"editor.wordHighlightBackground": "#4a4a7680",
+		"editor.wordHighlightStrongBackground": "#6a6a9680",
+		"editor.lineHighlightBackground": "#3e3d32",
+		"editorLineNumber.activeForeground": "#c2c2bf",
+		"editorCursor.foreground": "#f8f8f0",
+		"editorWhitespace.foreground": "#464741",
+		"editorIndentGuide.background": "#464741",
+		"editorIndentGuide.activeBackground": "#767771",
+		"editorGroupHeader.tabsBackground": "#1e1f1c",
+		"editorGroup.dropBackground": "#41433980",
+		"tab.inactiveBackground": "#34352f",
+		"tab.border": "#1e1f1c",
+		"tab.inactiveForeground": "#ccccc7", 
+		"tab.lastPinnedBorder": "#414339",
+		"widget.shadow": "#00000098",
+		"progressBar.background": "#75715E",
+		"badge.background": "#75715E",
+		"badge.foreground": "#f8f8f2",
+		"editorLineNumber.foreground": "#90908a",
+		"panelTitle.activeForeground": "#f8f8f2",
+		"panelTitle.activeBorder": "#75715E",
+		"panelTitle.inactiveForeground": "#75715E",
+		"panel.border": "#414339",
+		"settings.focusedRowBackground": "#4143395A",
+		"titleBar.activeBackground": "#1e1f1c",
+		"statusBar.background": "#414339",
+		"statusBar.noFolderBackground": "#414339",
+		"statusBar.debuggingBackground": "#75715E",
+		"statusBarItem.remoteBackground": "#AC6218",
+		"ports.iconRunningProcessForeground": "#ccccc7",
+		"activityBar.background": "#272822",
+		"activityBar.foreground": "#f8f8f2",
+		"sideBar.background": "#1e1f1c",
+		"sideBarSectionHeader.background": "#272822",
+		"menu.background": "#1e1f1c",
+		"menu.foreground": "#cccccc",
+		"pickerGroup.foreground": "#75715E",
+		"input.background": "#414339",
+		"inputOption.activeBorder": "#75715E",
+		"focusBorder": "#99947c",
+		"editorWidget.background": "#1e1f1c",
+		"debugToolBar.background": "#1e1f1c",
+		"diffEditor.insertedTextBackground": "#4b661680", 
+		"diffEditor.removedTextBackground": "#90274A70", 
+		"inputValidation.errorBackground": "#90274A", 
+		"inputValidation.errorBorder": "#f92672",
+		"inputValidation.warningBackground": "#848528", 
+		"inputValidation.warningBorder": "#e2e22e",
+		"inputValidation.infoBackground": "#546190", 
+		"inputValidation.infoBorder": "#819aff",
+		"editorHoverWidget.background": "#414339",
+		"editorHoverWidget.border": "#75715E",
+		"editorSuggestWidget.background": "#272822",
+		"editorSuggestWidget.border": "#75715E",
+		"editorGroup.border": "#34352f",
+		"peekView.border": "#75715E",
+		"peekViewEditor.background": "#272822",
+		"peekViewResult.background": "#1e1f1c",
+		"peekViewTitle.background": "#1e1f1c",
+		"peekViewResult.selectionBackground": "#414339",
+		"peekViewResult.matchHighlightBackground": "#75715E",
+		"peekViewEditor.matchHighlightBackground": "#75715E",
+		"terminal.ansiBlack": "#333333",
+		"terminal.ansiRed": "#C4265E", 
+		"terminal.ansiGreen": "#86B42B",
+		"terminal.ansiYellow": "#B3B42B",
+		"terminal.ansiBlue": "#6A7EC8",
+		"terminal.ansiMagenta": "#8C6BC8",
+		"terminal.ansiCyan": "#56ADBC",
+		"terminal.ansiWhite": "#e3e3dd",
+		"terminal.ansiBrightBlack": "#666666",
+		"terminal.ansiBrightRed": "#f92672",
+		"terminal.ansiBrightGreen": "#A6E22E",
+		"terminal.ansiBrightYellow": "#e2e22e", 
+		"terminal.ansiBrightBlue": "#819aff", 
+		"terminal.ansiBrightMagenta": "#AE81FF",
+		"terminal.ansiBrightCyan": "#66D9EF",
+		"terminal.ansiBrightWhite": "#f8f8f2"
+	},
+	"tokenColors": [
+		{
+			"settings": {
+				"foreground": "#F8F8F2"
+			}
+		},
+		{
+			"scope": [
+				"meta.embedded",
+				"source.groovy.embedded",
+				"string meta.image.inline.markdown",
+				"variable.legacy.builtin.python"
+			],
+			"settings": {
+				"foreground": "#F8F8F2"
+			}
+		},
+		{
+			"name": "Comment",
+			"scope": "comment",
+			"settings": {
+				"foreground": "#88846f"
+			}
+		},
+		{
+			"name": "String",
+			"scope": "string",
+			"settings": {
+				"foreground": "#E6DB74"
+			}
+		},
+		{
+			"name": "Template Definition",
+			"scope": [
+				"punctuation.definition.template-expression",
+				"punctuation.section.embedded"
+			],
+			"settings": {
+				"foreground": "#F92672"
+			}
+		},
+		{
+			"name": "Reset JavaScript string interpolation expression",
+			"scope": [
+				"meta.template.expression"
+			],
+			"settings": {
+				"foreground": "#F8F8F2"
+			}
+		},
+		{
+			"name": "Number",
+			"scope": "constant.numeric",
+			"settings": {
+				"foreground": "#AE81FF"
+			}
+		},
+		{
+			"name": "Built-in constant",
+			"scope": "constant.language",
+			"settings": {
+				"foreground": "#AE81FF"
+			}
+		},
+		{
+			"name": "User-defined constant",
+			"scope": "constant.character, constant.other",
+			"settings": {
+				"foreground": "#AE81FF"
+			}
+		},
+		{
+			"name": "Variable",
+			"scope": "variable",
+			"settings": {
+				"fontStyle": "",
+				"foreground": "#F8F8F2"
+			}
+		},
+		{
+			"name": "Keyword",
+			"scope": "keyword",
+			"settings": {
+				"foreground": "#F92672"
+			}
+		},
+		{
+			"name": "Storage",
+			"scope": "storage",
+			"settings": {
+				"fontStyle": "",
+				"foreground": "#F92672"
+			}
+		},
+		{
+			"name": "Storage type",
+			"scope": "storage.type",
+			"settings": {
+				"fontStyle": "italic",
+				"foreground": "#66D9EF"
+			}
+		},
+		{
+			"name": "Class name",
+			"scope": "entity.name.type, entity.name.class, entity.name.namespace, entity.name.scope-resolution",
+			"settings": {
+				"fontStyle": "underline",
+				"foreground": "#A6E22E"
+			}
+		},
+		{
+			"name": "Inherited class",
+			"scope": [
+				"entity.other.inherited-class",
+				"punctuation.separator.namespace.ruby"
+			],
+			"settings": {
+				"fontStyle": "italic underline",
+				"foreground": "#A6E22E"
+			}
+		},
+		{
+			"name": "Function name",
+			"scope": "entity.name.function",
+			"settings": {
+				"fontStyle": "",
+				"foreground": "#A6E22E"
+			}
+		},
+		{
+			"name": "Function argument",
+			"scope": "variable.parameter",
+			"settings": {
+				"fontStyle": "italic",
+				"foreground": "#FD971F"
+			}
+		},
+		{
+			"name": "Tag name",
+			"scope": "entity.name.tag",
+			"settings": {
+				"fontStyle": "",
+				"foreground": "#F92672"
+			}
+		},
+		{
+			"name": "Tag attribute",
+			"scope": "entity.other.attribute-name",
+			"settings": {
+				"fontStyle": "",
+				"foreground": "#A6E22E"
+			}
+		},
+		{
+			"name": "Library function",
+			"scope": "support.function",
+			"settings": {
+				"fontStyle": "",
+				"foreground": "#66D9EF"
+			}
+		},
+		{
+			"name": "Library constant",
+			"scope": "support.constant",
+			"settings": {
+				"fontStyle": "",
+				"foreground": "#66D9EF"
+			}
+		},
+		{
+			"name": "Library class/type",
+			"scope": "support.type, support.class",
+			"settings": {
+				"fontStyle": "italic",
+				"foreground": "#66D9EF"
+			}
+		},
+		{
+			"name": "Library variable",
+			"scope": "support.other.variable",
+			"settings": {
+				"fontStyle": ""
+			}
+		},
+		{
+			"name": "Invalid",
+			"scope": "invalid",
+			"settings": {
+				"fontStyle": "",
+				"foreground": "#F44747"
+			}
+		},
+		{
+			"name": "Invalid deprecated",
+			"scope": "invalid.deprecated",
+			"settings": {
+				"foreground": "#F44747"
+			}
+		},
+		{
+			"name": "JSON String",
+			"scope": "meta.structure.dictionary.json string.quoted.double.json",
+			"settings": {
+				"foreground": "#CFCFC2"
+			}
+		},
+		{
+			"name": "diff.header",
+			"scope": "meta.diff, meta.diff.header",
+			"settings": {
+				"foreground": "#75715E"
+			}
+		},
+		{
+			"name": "diff.deleted",
+			"scope": "markup.deleted",
+			"settings": {
+				"foreground": "#F92672"
+			}
+		},
+		{
+			"name": "diff.inserted",
+			"scope": "markup.inserted",
+			"settings": {
+				"foreground": "#A6E22E"
+			}
+		},
+		{
+			"name": "diff.changed",
+			"scope": "markup.changed",
+			"settings": {
+				"foreground": "#E6DB74"
+			}
+		},
+		{
+			"scope": "constant.numeric.line-number.find-in-files - match",
+			"settings": {
+				"foreground": "#AE81FFA0"
+			}
+		},
+		{
+			"scope": "entity.name.filename.find-in-files",
+			"settings": {
+				"foreground": "#E6DB74"
+			}
+		},
+		{
+			"name": "Markup Quote",
+			"scope": "markup.quote",
+			"settings": {
+				"foreground": "#F92672"
+			}
+		},
+		{
+			"name": "Markup Lists",
+			"scope": "markup.list",
+			"settings": {
+				"foreground": "#E6DB74"
+			}
+		},
+		{
+			"name": "Markup Styling",
+			"scope": "markup.bold, markup.italic",
+			"settings": {
+				"foreground": "#66D9EF"
+			}
+		},
+		{
+			"name": "Markup Inline",
+			"scope": "markup.inline.raw",
+			"settings": {
+				"fontStyle": "",
+				"foreground": "#FD971F"
+			}
+		},
+		{
+			"name": "Markup Headings",
+			"scope": "markup.heading",
+			"settings": {
+				"foreground": "#A6E22E"
+			}
+		},
+		{
+			"name": "Markup Setext Header",
+			"scope": "markup.heading.setext",
+			"settings": {
+				"foreground": "#A6E22E",
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"name": "Markup Headings",
+			"scope": "markup.heading.markdown",
+			"settings": {
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"name": "Markdown Quote",
+			"scope": "markup.quote.markdown",
+			"settings": {
+				"fontStyle": "italic",
+				"foreground": "#75715E"
+			}
+		},
+		{
+			"name": "Markdown Bold",
+			"scope": "markup.bold.markdown",
+			"settings": {
+				"fontStyle": "bold"
+			}
+		},
+		{
+			"name": "Markdown Link Title/Description",
+			"scope": "string.other.link.title.markdown,string.other.link.description.markdown",
+			"settings": {
+				"foreground": "#AE81FF"
+			}
+		},
+		{
+			"name": "Markdown Underline Link/Image",
+			"scope": "markup.underline.link.markdown,markup.underline.link.image.markdown",
+			"settings": {
+				"foreground": "#E6DB74"
+			}
+		},
+		{
+			"name": "Markdown Emphasis",
+			"scope": "markup.italic.markdown",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"scope": "markup.strikethrough",
+			"settings": {
+				"fontStyle": "strikethrough"
+			}
+		},
+		{
+			"name": "Markdown Punctuation Definition Link",
+			"scope": "markup.list.unnumbered.markdown, markup.list.numbered.markdown",
+			"settings": {
+				"foreground": "#f8f8f2"
+			}
+		},
+		{
+			"name": "Markdown List Punctuation",
+			"scope": [
+				"punctuation.definition.list.begin.markdown"
+			],
+			"settings": {
+				"foreground": "#A6E22E"
+			}
+		},
+		{
+			"scope": "token.info-token",
+			"settings": {
+				"foreground": "#6796e6"
+			}
+		},
+		{
+			"scope": "token.warn-token",
+			"settings": {
+				"foreground": "#cd9731"
+			}
+		},
+		{
+			"scope": "token.error-token",
+			"settings": {
+				"foreground": "#f44747"
+			}
+		},
+		{
+			"scope": "token.debug-token",
+			"settings": {
+				"foreground": "#b267e6"
+			}
+		},
+		{
+			"name": "this.self",
+			"scope": "variable.language",
+			"settings": {
+				"foreground": "#FD971F"
+			}
+		}
+	],
+	"semanticHighlighting": true
+}

--- a/microbenchmark/src/androidTest/assets/themes/one_dark_pro.json
+++ b/microbenchmark/src/androidTest/assets/themes/one_dark_pro.json
@@ -1,0 +1,2277 @@
+{
+  "name": "One Dark Pro",
+  "type": "dark",
+  "semanticHighlighting": true,
+  "semanticTokenColors": {
+    "annotation:dart": {
+      "foreground": "#d19a66"
+    },
+    "enumMember": {
+      "foreground": "#56b6c2"
+    },
+    "macro": {
+      "foreground": "#d19a66"
+    },
+    "memberOperatorOverload": {
+      "foreground": "#c678dd"
+    },
+    "parameter.label:dart": {
+      "foreground": "#abb2bf"
+    },
+    "property:dart": {
+      "foreground": "#d19a66"
+    },
+    "tomlArrayKey": {
+      "foreground": "#e5c07b"
+    },
+    "variable:dart": {
+      "foreground": "#d19a66"
+    },
+    "variable.constant": {
+      "foreground": "#d19a66"
+    },
+    "variable.defaultLibrary": {
+      "foreground": "#e5c07b"
+    }
+  },
+  "tokenColors": [
+    {
+      "scope": "meta.embedded",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "unison punctuation",
+      "scope": "punctuation.definition.delayed.unison,punctuation.definition.list.begin.unison,punctuation.definition.list.end.unison,punctuation.definition.ability.begin.unison,punctuation.definition.ability.end.unison,punctuation.operator.assignment.as.unison,punctuation.separator.pipe.unison,punctuation.separator.delimiter.unison,punctuation.definition.hash.unison",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "haskell variable generic-type",
+      "scope": "variable.other.generic-type.haskell",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "haskell storage type",
+      "scope": "storage.type.haskell",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "support.variable.magic.python",
+      "scope": "support.variable.magic.python",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "punctuation.separator.parameters.python",
+      "scope": "punctuation.separator.period.python,punctuation.separator.element.python,punctuation.parenthesis.begin.python,punctuation.parenthesis.end.python",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "variable.parameter.function.language.special.self.python",
+      "scope": "variable.parameter.function.language.special.self.python",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "variable.parameter.function.language.special.cls.python",
+      "scope": "variable.parameter.function.language.special.cls.python",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "storage.modifier.lifetime.rust",
+      "scope": "storage.modifier.lifetime.rust",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "support.function.std.rust",
+      "scope": "support.function.std.rust",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "entity.name.lifetime.rust",
+      "scope": "entity.name.lifetime.rust",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "variable.language.rust",
+      "scope": "variable.language.rust",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "support.constant.edge",
+      "scope": "support.constant.edge",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "regexp constant character-class",
+      "scope": "constant.other.character-class.regexp",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "keyword.operator",
+      "scope": [
+        "keyword.operator.word"
+      ],
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "regexp operator.quantifier",
+      "scope": "keyword.operator.quantifier.regexp",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Text",
+      "scope": "variable.parameter.function",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Comment Markup Link",
+      "scope": "comment markup.link",
+      "settings": {
+        "foreground": "#5c6370"
+      }
+    },
+    {
+      "name": "markup diff",
+      "scope": "markup.changed.diff",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "diff",
+      "scope": "meta.diff.header.from-file,meta.diff.header.to-file,punctuation.definition.from-file.diff,punctuation.definition.to-file.diff",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "inserted.diff",
+      "scope": "markup.inserted.diff",
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "deleted.diff",
+      "scope": "markup.deleted.diff",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "c++ function",
+      "scope": "meta.function.c,meta.function.cpp",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "c++ block",
+      "scope": "punctuation.section.block.begin.bracket.curly.cpp,punctuation.section.block.end.bracket.curly.cpp,punctuation.terminator.statement.c,punctuation.section.block.begin.bracket.curly.c,punctuation.section.block.end.bracket.curly.c,punctuation.section.parens.begin.bracket.round.c,punctuation.section.parens.end.bracket.round.c,punctuation.section.parameters.begin.bracket.round.c,punctuation.section.parameters.end.bracket.round.c",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "js/ts punctuation separator key-value",
+      "scope": "punctuation.separator.key-value",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "js/ts import keyword",
+      "scope": "keyword.operator.expression.import",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "math js/ts",
+      "scope": "support.constant.math",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "math property js/ts",
+      "scope": "support.constant.property.math",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "js/ts variable.other.constant",
+      "scope": "variable.other.constant",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "java type",
+      "scope": [
+        "storage.type.annotation.java",
+        "storage.type.object.array.java"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "java source",
+      "scope": "source.java",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "java modifier.import",
+      "scope": "punctuation.section.block.begin.java,punctuation.section.block.end.java,punctuation.definition.method-parameters.begin.java,punctuation.definition.method-parameters.end.java,meta.method.identifier.java,punctuation.section.method.begin.java,punctuation.section.method.end.java,punctuation.terminator.java,punctuation.section.class.begin.java,punctuation.section.class.end.java,punctuation.section.inner-class.begin.java,punctuation.section.inner-class.end.java,meta.method-call.java,punctuation.section.class.begin.bracket.curly.java,punctuation.section.class.end.bracket.curly.java,punctuation.section.method.begin.bracket.curly.java,punctuation.section.method.end.bracket.curly.java,punctuation.separator.period.java,punctuation.bracket.angle.java,punctuation.definition.annotation.java,meta.method.body.java",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "java modifier.import",
+      "scope": "meta.method.java",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "java modifier.import",
+      "scope": "storage.modifier.import.java,storage.type.java,storage.type.generic.java",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "java instanceof",
+      "scope": "keyword.operator.instanceof.java",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "java variable.name",
+      "scope": "meta.definition.variable.name.java",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "operator logical",
+      "scope": "keyword.operator.logical",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "operator bitwise",
+      "scope": "keyword.operator.bitwise",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "operator channel",
+      "scope": "keyword.operator.channel",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "support.constant.property-value.scss",
+      "scope": "support.constant.property-value.scss,support.constant.property-value.css",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "CSS/SCSS/LESS Operators",
+      "scope": "keyword.operator.css,keyword.operator.scss,keyword.operator.less",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "css color standard name",
+      "scope": "support.constant.color.w3c-standard-color-name.css,support.constant.color.w3c-standard-color-name.scss",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "css comma",
+      "scope": "punctuation.separator.list.comma.css",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "css attribute-name.id",
+      "scope": "support.constant.color.w3c-standard-color-name.css",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "css property-name",
+      "scope": "support.type.vendored.property-name.css",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "js/ts module",
+      "scope": "support.module.node,support.type.object.module,support.module.node",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "entity.name.type.module",
+      "scope": "entity.name.type.module",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "js variable readwrite",
+      "scope": "variable.other.readwrite,meta.object-literal.key,support.variable.property,support.variable.object.process,support.variable.object.node",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "js/ts json",
+      "scope": "support.constant.json",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "js/ts Keyword",
+      "scope": [
+        "keyword.operator.expression.instanceof",
+        "keyword.operator.new",
+        "keyword.operator.ternary",
+        "keyword.operator.optional",
+        "keyword.operator.expression.keyof"
+      ],
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "js/ts console",
+      "scope": "support.type.object.console",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "js/ts support.variable.property.process",
+      "scope": "support.variable.property.process",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "js console function",
+      "scope": "entity.name.function,support.function.console",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "keyword.operator.misc.rust",
+      "scope": "keyword.operator.misc.rust",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "keyword.operator.sigil.rust",
+      "scope": "keyword.operator.sigil.rust",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "operator",
+      "scope": "keyword.operator.delete",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "js dom",
+      "scope": "support.type.object.dom",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "js dom variable",
+      "scope": "support.variable.dom,support.variable.property.dom",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "keyword.operator",
+      "scope": "keyword.operator.arithmetic,keyword.operator.comparison,keyword.operator.decrement,keyword.operator.increment,keyword.operator.relational",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "C operator assignment",
+      "scope": "keyword.operator.assignment.c,keyword.operator.comparison.c,keyword.operator.c,keyword.operator.increment.c,keyword.operator.decrement.c,keyword.operator.bitwise.shift.c,keyword.operator.assignment.cpp,keyword.operator.comparison.cpp,keyword.operator.cpp,keyword.operator.increment.cpp,keyword.operator.decrement.cpp,keyword.operator.bitwise.shift.cpp",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Punctuation",
+      "scope": "punctuation.separator.delimiter",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Other punctuation .c",
+      "scope": "punctuation.separator.c,punctuation.separator.cpp",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "C type posix-reserved",
+      "scope": "support.type.posix-reserved.c,support.type.posix-reserved.cpp",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "keyword.operator.sizeof.c",
+      "scope": "keyword.operator.sizeof.c,keyword.operator.sizeof.cpp",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "python parameter",
+      "scope": "variable.parameter.function.language.python",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "python type",
+      "scope": "support.type.python",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "python logical",
+      "scope": "keyword.operator.logical.python",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "pyCs",
+      "scope": "variable.parameter.function.python",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "python block",
+      "scope": "punctuation.definition.arguments.begin.python,punctuation.definition.arguments.end.python,punctuation.separator.arguments.python,punctuation.definition.list.begin.python,punctuation.definition.list.end.python",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "python function-call.generic",
+      "scope": "meta.function-call.generic.python",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "python placeholder reset to normal string",
+      "scope": "constant.character.format.placeholder.other.python",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Operators",
+      "scope": "keyword.operator",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Compound Assignment Operators",
+      "scope": "keyword.operator.assignment.compound",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Compound Assignment Operators js/ts",
+      "scope": "keyword.operator.assignment.compound.js,keyword.operator.assignment.compound.ts",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "Keywords",
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Namespaces",
+      "scope": "entity.name.namespace",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Variables",
+      "scope": "variable",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Variables",
+      "scope": "variable.c",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Language variables",
+      "scope": "variable.language",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Java Variables",
+      "scope": "token.variable.parameter.java",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Java Imports",
+      "scope": "import.storage.java",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Packages",
+      "scope": "token.package.keyword",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Packages",
+      "scope": "token.package",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Functions",
+      "scope": [
+        "entity.name.function",
+        "meta.require",
+        "support.function.any-method",
+        "variable.function"
+      ],
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "Classes",
+      "scope": "entity.name.type.namespace",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Classes",
+      "scope": "support.class, entity.name.type.class",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Class name",
+      "scope": "entity.name.class.identifier.namespace.type",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Class name",
+      "scope": [
+        "entity.name.class",
+        "variable.other.class.js",
+        "variable.other.class.ts"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Class name php",
+      "scope": "variable.other.class.php",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Type Name",
+      "scope": "entity.name.type",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Keyword Control",
+      "scope": "keyword.control",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Control Elements",
+      "scope": "control.elements, keyword.operator.less",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Methods",
+      "scope": "keyword.other.special-method",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "Storage",
+      "scope": "storage",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Storage JS TS",
+      "scope": "token.storage",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Source Js Keyword Operator Delete,source Js Keyword Operator In,source Js Keyword Operator Of,source Js Keyword Operator Instanceof,source Js Keyword Operator New,source Js Keyword Operator Typeof,source Js Keyword Operator Void",
+      "scope": "keyword.operator.expression.delete,keyword.operator.expression.in,keyword.operator.expression.of,keyword.operator.expression.instanceof,keyword.operator.new,keyword.operator.expression.typeof,keyword.operator.expression.void",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Java Storage",
+      "scope": "token.storage.type.java",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Support",
+      "scope": "support.function",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "Support type",
+      "scope": "support.type.property-name",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] toml support",
+      "scope": "support.type.property-name.toml, support.type.property-name.table.toml, support.type.property-name.array.toml",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Support type",
+      "scope": "support.constant.property-value",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Support type",
+      "scope": "support.constant.font-name",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Meta tag",
+      "scope": "meta.tag",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Strings",
+      "scope": "string",
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "Constant other symbol",
+      "scope": "constant.other.symbol",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "Integers",
+      "scope": "constant.numeric",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Constants",
+      "scope": "constant",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Constants",
+      "scope": "punctuation.definition.constant",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Tags",
+      "scope": "entity.name.tag",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Attributes",
+      "scope": "entity.other.attribute-name",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Attribute IDs",
+      "scope": "entity.other.attribute-name.id",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "Attribute class",
+      "scope": "entity.other.attribute-name.class.css",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Selector",
+      "scope": "meta.selector",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Headings",
+      "scope": "markup.heading",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Headings",
+      "scope": "markup.heading punctuation.definition.heading, entity.name.section",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "Units",
+      "scope": "keyword.other.unit",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Bold",
+      "scope": "markup.bold,todo.bold",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Bold",
+      "scope": "punctuation.definition.bold",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "markup Italic",
+      "scope": "markup.italic, punctuation.definition.italic,todo.emphasis",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "emphasis md",
+      "scope": "emphasis md",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown headings",
+      "scope": "entity.name.section.markdown",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown heading Punctuation Definition",
+      "scope": "punctuation.definition.heading.markdown",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "punctuation.definition.list.begin.markdown",
+      "scope": "punctuation.definition.list.begin.markdown",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown heading setext",
+      "scope": "markup.heading.setext",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Bold",
+      "scope": "punctuation.definition.bold.markdown",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+      "scope": "markup.inline.raw.markdown",
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+      "scope": "markup.inline.raw.string.markdown",
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Inline Raw punctuation",
+      "scope": "punctuation.definition.raw.markdown",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown List Punctuation Definition",
+      "scope": "punctuation.definition.list.markdown",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition String",
+      "scope": [
+        "punctuation.definition.string.begin.markdown",
+        "punctuation.definition.string.end.markdown",
+        "punctuation.definition.metadata.markdown"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "beginning.punctuation.definition.list.markdown",
+      "scope": [
+        "beginning.punctuation.definition.list.markdown"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Link",
+      "scope": "punctuation.definition.metadata.markdown",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Underline Link/Image",
+      "scope": "markup.underline.link.markdown,markup.underline.link.image.markdown",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Link Title/Description",
+      "scope": "string.other.link.title.markdown,string.other.link.description.markdown",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc Inline Raw",
+      "scope": "markup.raw.monospace.asciidoc",
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc Inline Raw Punctuation Definition",
+      "scope": "punctuation.definition.asciidoc",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc List Punctuation Definition",
+      "scope": "markup.list.asciidoc",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc underline link",
+      "scope": "markup.link.asciidoc,markup.other.url.asciidoc",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Asciidoc link name",
+      "scope": "string.unquoted.asciidoc,markup.other.url.asciidoc",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "Regular Expressions",
+      "scope": "string.regexp",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "Embedded",
+      "scope": "punctuation.section.embedded, variable.interpolation",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Embedded",
+      "scope": "punctuation.section.embedded.begin,punctuation.section.embedded.end",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "illegal",
+      "scope": "invalid.illegal",
+      "settings": {
+        "foreground": "#ffffff"
+      }
+    },
+    {
+      "name": "illegal",
+      "scope": "invalid.illegal.bad-ampersand.html",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "scope": "invalid.illegal.unrecognized-tag.html",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Broken",
+      "scope": "invalid.broken",
+      "settings": {
+        "foreground": "#ffffff"
+      }
+    },
+    {
+      "name": "Deprecated",
+      "scope": "invalid.deprecated",
+      "settings": {
+        "foreground": "#ffffff"
+      }
+    },
+    {
+      "name": "html Deprecated",
+      "scope": "invalid.deprecated.entity.other.attribute-name.html",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "Unimplemented",
+      "scope": "invalid.unimplemented",
+      "settings": {
+        "foreground": "#ffffff"
+      }
+    },
+    {
+      "name": "Source Json Meta Structure Dictionary Json > String Quoted Json",
+      "scope": "source.json meta.structure.dictionary.json > string.quoted.json",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Source Json Meta Structure Dictionary Json > String Quoted Json > Punctuation String",
+      "scope": "source.json meta.structure.dictionary.json > string.quoted.json > punctuation.string",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Source Json Meta Structure Dictionary Json > Value Json > String Quoted Json,source Json Meta Structure Array Json > Value Json > String Quoted Json,source Json Meta Structure Dictionary Json > Value Json > String Quoted Json > Punctuation,source Json Meta Structure Array Json > Value Json > String Quoted Json > Punctuation",
+      "scope": "source.json meta.structure.dictionary.json > value.json > string.quoted.json,source.json meta.structure.array.json > value.json > string.quoted.json,source.json meta.structure.dictionary.json > value.json > string.quoted.json > punctuation,source.json meta.structure.array.json > value.json > string.quoted.json > punctuation",
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "Source Json Meta Structure Dictionary Json > Constant Language Json,source Json Meta Structure Array Json > Constant Language Json",
+      "scope": "source.json meta.structure.dictionary.json > constant.language.json,source.json meta.structure.array.json > constant.language.json",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JSON Property Name",
+      "scope": "support.type.property-name.json",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] JSON Punctuation for Property Name",
+      "scope": "support.type.property-name.json punctuation",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "laravel blade tag",
+      "scope": "text.html.laravel-blade source.php.embedded.line.html entity.name.tag.laravel-blade",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "laravel blade @",
+      "scope": "text.html.laravel-blade source.php.embedded.line.html support.constant.laravel-blade",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "use statement for other classes",
+      "scope": "support.other.namespace.use.php,support.other.namespace.use-as.php,entity.other.alias.php,meta.interface.php",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "error suppression",
+      "scope": "keyword.operator.error-control.php",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "php instanceof",
+      "scope": "keyword.operator.type.php",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "style double quoted array index normal begin",
+      "scope": "punctuation.section.array.begin.php",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "style double quoted array index normal end",
+      "scope": "punctuation.section.array.end.php",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "php illegal.non-null-typehinted",
+      "scope": "invalid.illegal.non-null-typehinted.php",
+      "settings": {
+        "foreground": "#f44747"
+      }
+    },
+    {
+      "name": "php types",
+      "scope": "storage.type.php,meta.other.type.phpdoc.php,keyword.other.type.php,keyword.other.array.phpdoc.php",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "php call-function",
+      "scope": "meta.function-call.php,meta.function-call.object.php,meta.function-call.static.php",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "php function-resets",
+      "scope": "punctuation.definition.parameters.begin.bracket.round.php,punctuation.definition.parameters.end.bracket.round.php,punctuation.separator.delimiter.php,punctuation.section.scope.begin.php,punctuation.section.scope.end.php,punctuation.terminator.expression.php,punctuation.definition.arguments.begin.bracket.round.php,punctuation.definition.arguments.end.bracket.round.php,punctuation.definition.storage-type.begin.bracket.round.php,punctuation.definition.storage-type.end.bracket.round.php,punctuation.definition.array.begin.bracket.round.php,punctuation.definition.array.end.bracket.round.php,punctuation.definition.begin.bracket.round.php,punctuation.definition.end.bracket.round.php,punctuation.definition.begin.bracket.curly.php,punctuation.definition.end.bracket.curly.php,punctuation.definition.section.switch-block.end.bracket.curly.php,punctuation.definition.section.switch-block.start.bracket.curly.php,punctuation.definition.section.switch-block.begin.bracket.curly.php,punctuation.definition.section.switch-block.end.bracket.curly.php",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "support php constants",
+      "scope": "support.constant.core.rust",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "support php constants",
+      "scope": "support.constant.ext.php,support.constant.std.php,support.constant.core.php,support.constant.parser-token.php",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "php goto",
+      "scope": "entity.name.goto-label.php,support.other.php",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "php logical/bitwise operator",
+      "scope": "keyword.operator.logical.php,keyword.operator.bitwise.php,keyword.operator.arithmetic.php",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "php regexp operator",
+      "scope": "keyword.operator.regexp.php",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "php comparison",
+      "scope": "keyword.operator.comparison.php",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "php heredoc/nowdoc",
+      "scope": "keyword.operator.heredoc.php,keyword.operator.nowdoc.php",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "python function decorator @",
+      "scope": "meta.function.decorator.python",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "python function support",
+      "scope": "support.token.decorator.python,meta.function.decorator.identifier.python",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "parameter function js/ts",
+      "scope": "function.parameter",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "brace function",
+      "scope": "function.brace",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "parameter function ruby cs",
+      "scope": "function.parameter.ruby, function.parameter.cs",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "constant.language.symbol.ruby",
+      "scope": "constant.language.symbol.ruby",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "constant.language.symbol.hashkey.ruby",
+      "scope": "constant.language.symbol.hashkey.ruby",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "rgb-value",
+      "scope": "rgb-value",
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "rgb value",
+      "scope": "inline-color-decoration rgb-value",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "rgb value less",
+      "scope": "less rgb-value",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "sass selector",
+      "scope": "selector.sass",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "ts primitive/builtin types",
+      "scope": "support.type.primitive.ts,support.type.builtin.ts,support.type.primitive.tsx,support.type.builtin.tsx",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "block scope",
+      "scope": "block.scope.end,block.scope.begin",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "cs storage type",
+      "scope": "storage.type.cs",
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "cs local variable",
+      "scope": "entity.name.variable.local.cs",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "scope": "token.info-token",
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "scope": "token.warn-token",
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "scope": "token.error-token",
+      "settings": {
+        "foreground": "#f44747"
+      }
+    },
+    {
+      "scope": "token.debug-token",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "String interpolation",
+      "scope": [
+        "punctuation.definition.template-expression.begin",
+        "punctuation.definition.template-expression.end",
+        "punctuation.section.embedded"
+      ],
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Reset JavaScript string interpolation expression",
+      "scope": [
+        "meta.template.expression"
+      ],
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Import module JS",
+      "scope": [
+        "keyword.operator.module"
+      ],
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "js Flowtype",
+      "scope": [
+        "support.type.type.flowtype"
+      ],
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "js Flow",
+      "scope": [
+        "support.type.primitive"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "js class prop",
+      "scope": [
+        "meta.property.object"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "js func parameter",
+      "scope": [
+        "variable.parameter.function.js"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "js template literals begin",
+      "scope": [
+        "keyword.other.template.begin"
+      ],
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "js template literals end",
+      "scope": [
+        "keyword.other.template.end"
+      ],
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "js template literals variable braces begin",
+      "scope": [
+        "keyword.other.substitution.begin"
+      ],
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "js template literals variable braces end",
+      "scope": [
+        "keyword.other.substitution.end"
+      ],
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "js operator.assignment",
+      "scope": [
+        "keyword.operator.assignment"
+      ],
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "go operator",
+      "scope": [
+        "keyword.operator.assignment.go"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "go operator",
+      "scope": [
+        "keyword.operator.arithmetic.go",
+        "keyword.operator.address.go"
+      ],
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "c arithmetic",
+      "scope": [
+        "keyword.operator.arithmetic.c",
+        "keyword.operator.arithmetic.cpp"
+      ],
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "Go package name",
+      "scope": [
+        "entity.name.package.go"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "elm prelude",
+      "scope": [
+        "support.type.prelude.elm"
+      ],
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "elm constant",
+      "scope": [
+        "support.constant.elm"
+      ],
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "template literal",
+      "scope": [
+        "punctuation.quasi.element"
+      ],
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "html/pug (jade) escaped characters and entities",
+      "scope": [
+        "constant.character.entity"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "styling css pseudo-elements/classes to be able to differentiate from classes which are the same colour",
+      "scope": [
+        "entity.other.attribute-name.pseudo-element",
+        "entity.other.attribute-name.pseudo-class"
+      ],
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "Clojure globals",
+      "scope": [
+        "entity.global.clojure"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Clojure symbols",
+      "scope": [
+        "meta.symbol.clojure"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Clojure constants",
+      "scope": [
+        "constant.keyword.clojure"
+      ],
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "CoffeeScript Function Argument",
+      "scope": [
+        "meta.arguments.coffee",
+        "variable.parameter.function.coffee"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Ini Default Text",
+      "scope": [
+        "source.ini"
+      ],
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "Makefile prerequisities",
+      "scope": [
+        "meta.scope.prerequisites.makefile"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Makefile text colour",
+      "scope": [
+        "source.makefile"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Groovy import names",
+      "scope": [
+        "storage.modifier.import.groovy"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Groovy Methods",
+      "scope": [
+        "meta.method.groovy"
+      ],
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "Groovy Variables",
+      "scope": [
+        "meta.definition.variable.name.groovy"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Groovy Inheritance",
+      "scope": [
+        "meta.definition.class.inherited.classes.groovy"
+      ],
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "HLSL Semantic",
+      "scope": [
+        "support.variable.semantic.hlsl"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "HLSL Types",
+      "scope": [
+        "support.type.texture.hlsl",
+        "support.type.sampler.hlsl",
+        "support.type.object.hlsl",
+        "support.type.object.rw.hlsl",
+        "support.type.fx.hlsl",
+        "support.type.object.hlsl"
+      ],
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "SQL Variables",
+      "scope": [
+        "text.variable",
+        "text.bracketed"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "types",
+      "scope": [
+        "support.type.swift",
+        "support.type.vb.asp"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "heading 1, keyword",
+      "scope": [
+        "entity.name.function.xi"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "heading 2, callable",
+      "scope": [
+        "entity.name.class.xi"
+      ],
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "heading 3, property",
+      "scope": [
+        "constant.character.character-class.regexp.xi"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "heading 4, type, class, interface",
+      "scope": [
+        "constant.regexp.xi"
+      ],
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "name": "heading 5, enums, preprocessor, constant, decorator",
+      "scope": [
+        "keyword.control.xi"
+      ],
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "name": "heading 6, number",
+      "scope": [
+        "invalid.xi"
+      ],
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "string",
+      "scope": [
+        "beginning.punctuation.definition.quote.markdown.xi"
+      ],
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "comments",
+      "scope": [
+        "beginning.punctuation.definition.list.markdown.xi"
+      ],
+      "settings": {
+        "foreground": "#7f848e"
+      }
+    },
+    {
+      "name": "link",
+      "scope": [
+        "constant.character.xi"
+      ],
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "accent",
+      "scope": [
+        "accent.xi"
+      ],
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "name": "wikiword",
+      "scope": [
+        "wikiword.xi"
+      ],
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "name": "language operators like '+', '-' etc",
+      "scope": [
+        "constant.other.color.rgb-value.xi"
+      ],
+      "settings": {
+        "foreground": "#ffffff"
+      }
+    },
+    {
+      "name": "elements to dim",
+      "scope": [
+        "punctuation.definition.tag.xi"
+      ],
+      "settings": {
+        "foreground": "#5c6370"
+      }
+    },
+    {
+      "name": "C++/C#",
+      "scope": [
+        "entity.name.label.cs",
+        "entity.name.scope-resolution.function.call",
+        "entity.name.scope-resolution.function.definition"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "Markdown underscore-style headers",
+      "scope": [
+        "entity.name.label.cs",
+        "markup.heading.setext.1.markdown",
+        "markup.heading.setext.2.markdown"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "meta.brace.square",
+      "scope": [
+        " meta.brace.square"
+      ],
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Comments",
+      "scope": "comment, punctuation.definition.comment",
+      "settings": {
+        "foreground": "#7f848e",
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "[VSCODE-CUSTOM] Markdown Quote",
+      "scope": "markup.quote.markdown",
+      "settings": {
+        "foreground": "#5c6370"
+      }
+    },
+    {
+      "name": "punctuation.definition.block.sequence.item.yaml",
+      "scope": "punctuation.definition.block.sequence.item.yaml",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "scope": [
+        "constant.language.symbol.elixir",
+        "constant.language.symbol.double-quoted.elixir"
+      ],
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.variable.parameter.cs"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "scope": [
+        "entity.name.variable.field.cs"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Deleted",
+      "scope": "markup.deleted",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "Inserted",
+      "scope": "markup.inserted",
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "Underline",
+      "scope": "markup.underline",
+      "settings": {
+        "fontStyle": "underline"
+      }
+    },
+    {
+      "name": "punctuation.section.embedded.begin.php",
+      "scope": [
+        "punctuation.section.embedded.begin.php",
+        "punctuation.section.embedded.end.php"
+      ],
+      "settings": {
+        "foreground": "#BE5046"
+      }
+    },
+    {
+      "name": "support.other.namespace.php",
+      "scope": [
+        "support.other.namespace.php"
+      ],
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Latex variable parameter",
+      "scope": [
+        "variable.parameter.function.latex"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "variable.other.object",
+      "scope": [
+        "variable.other.object"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "variable.other.constant.property",
+      "scope": [
+        "variable.other.constant.property"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "entity.other.inherited-class",
+      "scope": [
+        "entity.other.inherited-class"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "name": "c variable readwrite",
+      "scope": "variable.other.readwrite.c",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "name": "php scope",
+      "scope": "entity.name.variable.parameter.php,punctuation.separator.colon.php,constant.other.php",
+      "settings": {
+        "foreground": "#abb2bf"
+      }
+    },
+    {
+      "name": "Assembly",
+      "scope": [
+        "constant.numeric.decimal.asm.x86_64"
+      ],
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "scope": [
+        "support.other.parenthesis.regexp"
+      ],
+      "settings": {
+        "foreground": "#d19a66"
+      }
+    },
+    {
+      "scope": [
+        "constant.character.escape"
+      ],
+      "settings": {
+        "foreground": "#56b6c2"
+      }
+    },
+    {
+      "scope": [
+        "string.regexp"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "scope": [
+        "log.info"
+      ],
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "scope": [
+        "log.warning"
+      ],
+      "settings": {
+        "foreground": "#e5c07b"
+      }
+    },
+    {
+      "scope": [
+        "log.error"
+      ],
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "scope": "keyword.operator.expression.is",
+      "settings": {
+        "foreground": "#c678dd"
+      }
+    },
+    {
+      "scope": "entity.name.label",
+      "settings": {
+        "foreground": "#e06c75"
+      }
+    },
+    {
+      "scope": [
+        "support.class.math.block.environment.latex",
+        "constant.other.general.math.tex"
+      ],
+      "settings": {
+        "foreground": "#61afef"
+      }
+    },
+    {
+      "scope": [
+        "constant.character.math.tex"
+      ],
+      "settings": {
+        "foreground": "#98c379"
+      }
+    },
+    {
+      "name": "js/ts italic",
+      "scope": "entity.other.attribute-name.js,entity.other.attribute-name.ts,entity.other.attribute-name.jsx,entity.other.attribute-name.tsx,variable.parameter,variable.language.super",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "comment",
+      "scope": "comment.line.double-slash,comment.block.documentation",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    },
+    {
+      "name": "markup.italic.markdown",
+      "scope": "markup.italic.markdown",
+      "settings": {
+        "fontStyle": "italic"
+      }
+    }
+  ],
+  "colors": {
+    "actionBar.toggledBackground": "#525761",
+    "activityBar.background": "#282c34",
+    "activityBar.foreground": "#d7dae0",
+    "activityBarBadge.background": "#4d78cc",
+    "activityBarBadge.foreground": "#f8fafd",
+    "badge.background": "#282c34",
+    "button.background": "#404754",
+    "button.secondaryBackground": "#30333d",
+    "button.secondaryForeground": "#c0bdbd",
+    "checkbox.border": "#404754",
+    "debugToolBar.background": "#21252b",
+    "descriptionForeground": "#abb2bf",
+    "diffEditor.insertedTextBackground": "#00809b33",
+    "dropdown.background": "#21252b",
+    "dropdown.border": "#21252b",
+    "editor.background": "#282c34",
+    "editor.findMatchBackground": "#d19a6644",
+    "editor.findMatchBorder": "#ffffff5a",
+    "editor.findMatchHighlightBackground": "#ffffff22",
+    "editor.foreground": "#abb2bf",
+    "editor.lineHighlightBackground": "#2c313c",
+    "editor.selectionBackground": "#67769660",
+    "editor.selectionHighlightBackground": "#ffd33d44",
+    "editor.selectionHighlightBorder": "#dddddd",
+    "editor.wordHighlightBackground": "#d2e0ff2f",
+    "editor.wordHighlightBorder": "#7f848e",
+    "editor.wordHighlightStrongBackground": "#abb2bf26",
+    "editor.wordHighlightStrongBorder": "#7f848e",
+    "editorBracketHighlight.foreground1": "#d19a66",
+    "editorBracketHighlight.foreground2": "#c678dd",
+    "editorBracketHighlight.foreground3": "#56b6c2",
+    "editorBracketMatch.background": "#515a6b",
+    "editorBracketMatch.border": "#515a6b",
+    "editorCursor.background": "#ffffffc9",
+    "editorCursor.foreground": "#528bff",
+    "editorError.foreground": "#c24038",
+    "editorGroup.background": "#181a1f",
+    "editorGroup.border": "#181a1f",
+    "editorGroupHeader.tabsBackground": "#21252b",
+    "editorGutter.addedBackground": "#109868",
+    "editorGutter.deletedBackground": "#9A353D",
+    "editorGutter.modifiedBackground": "#948B60",
+    "editorHoverWidget.background": "#21252b",
+    "editorHoverWidget.border": "#181a1f",
+    "editorHoverWidget.highlightForeground": "#61afef",
+    "editorIndentGuide.activeBackground1": "#c8c8c859",
+    "editorIndentGuide.background1": "#3b4048",
+    "editorInlayHint.background": "#2c313c",
+    "editorInlayHint.foreground": "#abb2bf",
+    "editorLineNumber.activeForeground": "#abb2bf",
+    "editorLineNumber.foreground": "#495162",
+    "editorMarkerNavigation.background": "#21252b",
+    "editorOverviewRuler.addedBackground": "#109868",
+    "editorOverviewRuler.deletedBackground": "#9A353D",
+    "editorOverviewRuler.modifiedBackground": "#948B60",
+    "editorRuler.foreground": "#abb2bf26",
+    "editorSuggestWidget.background": "#21252b",
+    "editorSuggestWidget.border": "#181a1f",
+    "editorSuggestWidget.selectedBackground": "#2c313a",
+    "editorWarning.foreground": "#d19a66",
+    "editorWhitespace.foreground": "#ffffff1d",
+    "editorWidget.background": "#21252b",
+    "focusBorder": "#3e4452",
+    "gitDecoration.ignoredResourceForeground": "#636b78",
+    "input.background": "#1d1f23",
+    "input.foreground": "#abb2bf",
+    "list.activeSelectionBackground": "#2c313a",
+    "list.activeSelectionForeground": "#d7dae0",
+    "list.focusBackground": "#323842",
+    "list.focusForeground": "#f0f0f0",
+    "list.highlightForeground": "#ecebeb",
+    "list.hoverBackground": "#2c313a",
+    "list.hoverForeground": "#abb2bf",
+    "list.inactiveSelectionBackground": "#323842",
+    "list.inactiveSelectionForeground": "#d7dae0",
+    "list.warningForeground": "#d19a66",
+    "menu.foreground": "#abb2bf",
+    "menu.separatorBackground": "#343a45",
+    "minimapGutter.addedBackground": "#109868",
+    "minimapGutter.deletedBackground": "#9A353D",
+    "minimapGutter.modifiedBackground": "#948B60",
+    "multiDiffEditor.headerBackground": "#21252b",
+    "panel.border": "#3e4452",
+    "panelSectionHeader.background": "#21252b",
+    "peekViewEditor.background": "#1b1d23",
+    "peekViewEditor.matchHighlightBackground": "#29244b",
+    "peekViewResult.background": "#22262b",
+    "scrollbar.shadow": "#23252c",
+    "scrollbarSlider.activeBackground": "#747d9180",
+    "scrollbarSlider.background": "#4e566660",
+    "scrollbarSlider.hoverBackground": "#5a637580",
+    "settings.focusedRowBackground": "#282c34",
+    "settings.headerForeground": "#fff",
+    "sideBar.background": "#21252b",
+    "sideBar.foreground": "#abb2bf",
+    "sideBarSectionHeader.background": "#282c34",
+    "sideBarSectionHeader.foreground": "#abb2bf",
+    "statusBar.background": "#21252b",
+    "statusBar.debuggingBackground": "#cc6633",
+    "statusBar.debuggingBorder": "#ff000000",
+    "statusBar.debuggingForeground": "#ffffff",
+    "statusBar.foreground": "#9da5b4",
+    "statusBar.noFolderBackground": "#21252b",
+    "statusBarItem.remoteBackground": "#4d78cc",
+    "statusBarItem.remoteForeground": "#f8fafd",
+    "tab.activeBackground": "#282c34",
+    "tab.activeBorder": "#b4b4b4",
+    "tab.activeForeground": "#dcdcdc",
+    "tab.border": "#181a1f",
+    "tab.hoverBackground": "#323842",
+    "tab.inactiveBackground": "#21252b",
+    "tab.unfocusedHoverBackground": "#323842",
+    "terminal.ansiBlack": "#3f4451",
+    "terminal.ansiBlue": "#4aa5f0",
+    "terminal.ansiBrightBlack": "#4f5666",
+    "terminal.ansiBrightBlue": "#4dc4ff",
+    "terminal.ansiBrightCyan": "#4cd1e0",
+    "terminal.ansiBrightGreen": "#a5e075",
+    "terminal.ansiBrightMagenta": "#de73ff",
+    "terminal.ansiBrightRed": "#ff616e",
+    "terminal.ansiBrightWhite": "#e6e6e6",
+    "terminal.ansiBrightYellow": "#f0a45d",
+    "terminal.ansiCyan": "#42b3c2",
+    "terminal.ansiGreen": "#8cc265",
+    "terminal.ansiMagenta": "#c162de",
+    "terminal.ansiRed": "#e05561",
+    "terminal.ansiWhite": "#d7dae0",
+    "terminal.ansiYellow": "#d18f52",
+    "terminal.background": "#282c34",
+    "terminal.border": "#3e4452",
+    "terminal.foreground": "#abb2bf",
+    "terminal.selectionBackground": "#abb2bf30",
+    "textBlockQuote.background": "#2e3440",
+    "textBlockQuote.border": "#4b5362",
+    "textLink.foreground": "#61afef",
+    "textPreformat.foreground": "#d19a66",
+    "titleBar.activeBackground": "#282c34",
+    "titleBar.activeForeground": "#9da5b4",
+    "titleBar.inactiveBackground": "#282c34",
+    "titleBar.inactiveForeground": "#6b717d",
+    "tree.indentGuidesStroke": "#ffffff1d",
+    "walkThrough.embeddedEditorBackground": "#2e3440",
+    "welcomePage.buttonHoverBackground": "#404754"
+  }
+}

--- a/microbenchmark/src/androidTest/java/dev/hossain/benchmark/BenchmarkCodeSamples.kt
+++ b/microbenchmark/src/androidTest/java/dev/hossain/benchmark/BenchmarkCodeSamples.kt
@@ -1,0 +1,126 @@
+package dev.hossain.benchmark
+
+object BenchmarkCodeSamples {
+    val KOTLIN =
+        """
+        package com.example
+
+        import kotlinx.coroutines.*
+
+        data class User(val name: String, val age: Int)
+
+        suspend fun fetchUsers(): List<User> = coroutineScope {
+            val users = listOf(
+                User("Alice", 30),
+                User("Bob", 25),
+                User("Charlie", 35),
+            )
+            val adults = users.filter { it.age >= 30 }
+            adults.forEach { user ->
+                println("${'$'}{user.name} is ${'$'}{user.age} years old")
+            }
+            adults
+        }
+
+        fun main() = runBlocking {
+            val result = fetchUsers()
+            println("Found ${'$'}{result.size} adults")
+        }
+        """.trimIndent()
+
+    val PYTHON =
+        """
+        from dataclasses import dataclass
+        from typing import Optional
+        import asyncio
+
+        @dataclass
+        class User:
+            name: str
+            age: int
+            email: Optional[str] = None
+
+        async def fetch_users() -> list[User]:
+            # Simulate async data fetch
+            await asyncio.sleep(0.1)
+            return [
+                User("Alice", 30, "alice@example.com"),
+                User("Bob", 25),
+                User("Charlie", 35, "charlie@example.com"),
+            ]
+
+        async def main():
+            users = await fetch_users()
+            adults = [u for u in users if u.age >= 30]
+            for user in adults:
+                print(f"{user.name} is {user.age} years old")
+
+        if __name__ == "__main__":
+            asyncio.run(main())
+        """.trimIndent()
+
+    val JSON =
+        """
+        {
+          "users": [
+            {
+              "id": "usr_01",
+              "name": "Alice",
+              "age": 30,
+              "email": "alice@example.com",
+              "roles": ["admin", "viewer"],
+              "active": true
+            },
+            {
+              "id": "usr_02",
+              "name": "Bob",
+              "age": 25,
+              "email": null,
+              "roles": ["viewer"],
+              "active": false
+            }
+          ],
+          "meta": {
+            "total": 2,
+            "page": 1,
+            "perPage": 20
+          }
+        }
+        """.trimIndent()
+
+    val JAVASCRIPT =
+        """
+        const fetchUsers = async (baseUrl) => {
+          const response = await fetch(`${'$'}{baseUrl}/users`);
+          if (!response.ok) {
+            throw new Error(`HTTP error! status: ${'$'}{response.status}`);
+          }
+          return response.json();
+        };
+
+        class UserService {
+          constructor(baseUrl) {
+            this.baseUrl = baseUrl;
+            this.cache = new Map();
+          }
+
+          async getUser(id) {
+            if (this.cache.has(id)) {
+              return this.cache.get(id);
+            }
+            const users = await fetchUsers(this.baseUrl);
+            const user = users.find(u => u.id === id);
+            this.cache.set(id, user);
+            return user;
+          }
+        }
+
+        export default UserService;
+        """.trimIndent()
+
+    /** Kotlin code repeated 5× for medium-size benchmarks (~100 lines). */
+    val KOTLIN_MEDIUM: String = (1..5).joinToString("\n\n") { KOTLIN }
+
+    /** Kotlin code repeated ~40× for large-size benchmarks (~1000 lines). */
+    val KOTLIN_LARGE: String = (1..40).joinToString("\n\n") { KOTLIN }
+}

--- a/microbenchmark/src/androidTest/java/dev/hossain/benchmark/ComposeHighlightBenchmark.kt
+++ b/microbenchmark/src/androidTest/java/dev/hossain/benchmark/ComposeHighlightBenchmark.kt
@@ -1,0 +1,138 @@
+package dev.hossain.benchmark
+
+import android.content.Context
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.hossain.highlight.engine.HighlightEngine
+import dev.hossain.highlight.engine.HighlightTheme
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+class ComposeHighlightBenchmark {
+
+    @get:Rule
+    val benchmarkRule = BenchmarkRule()
+
+    private lateinit var scenario: ActivityScenario<BenchmarkActivity>
+    private lateinit var engine: HighlightEngine
+    private lateinit var lightTheme: HighlightTheme
+    private lateinit var darkTheme: HighlightTheme
+
+    @Before
+    fun setup() {
+        scenario = ActivityScenario.launch(BenchmarkActivity::class.java)
+
+        val latch = CountDownLatch(1)
+        scenario.onActivity { activity ->
+            engine = HighlightEngine(activity as Context)
+            lightTheme = HighlightTheme.tomorrow(activity)
+            darkTheme = HighlightTheme.tomorrowNight(activity)
+            latch.countDown()
+        }
+        latch.await(10, TimeUnit.SECONDS)
+
+        // Initialize the engine (warm up WebView)
+        runBlocking {
+            engine.initialize()
+        }
+    }
+
+    @After
+    fun teardown() {
+        engine.destroy()
+        scenario.close()
+    }
+
+    @Test
+    fun highlightKotlin_bothThemes() {
+        benchmarkRule.measureRepeated {
+            runBlocking {
+                engine.highlightBothThemes(
+                    code = BenchmarkCodeSamples.KOTLIN,
+                    language = "kotlin",
+                    lightTheme = lightTheme,
+                    darkTheme = darkTheme,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun highlightPython_bothThemes() {
+        benchmarkRule.measureRepeated {
+            runBlocking {
+                engine.highlightBothThemes(
+                    code = BenchmarkCodeSamples.PYTHON,
+                    language = "python",
+                    lightTheme = lightTheme,
+                    darkTheme = darkTheme,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun highlightJson_bothThemes() {
+        benchmarkRule.measureRepeated {
+            runBlocking {
+                engine.highlightBothThemes(
+                    code = BenchmarkCodeSamples.JSON,
+                    language = "json",
+                    lightTheme = lightTheme,
+                    darkTheme = darkTheme,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun highlightJavaScript_bothThemes() {
+        benchmarkRule.measureRepeated {
+            runBlocking {
+                engine.highlightBothThemes(
+                    code = BenchmarkCodeSamples.JAVASCRIPT,
+                    language = "javascript",
+                    lightTheme = lightTheme,
+                    darkTheme = darkTheme,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun highlightKotlin_medium_bothThemes() {
+        benchmarkRule.measureRepeated {
+            runBlocking {
+                engine.highlightBothThemes(
+                    code = BenchmarkCodeSamples.KOTLIN_MEDIUM,
+                    language = "kotlin",
+                    lightTheme = lightTheme,
+                    darkTheme = darkTheme,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun highlightKotlin_large_bothThemes() {
+        benchmarkRule.measureRepeated {
+            runBlocking {
+                engine.highlightBothThemes(
+                    code = BenchmarkCodeSamples.KOTLIN_LARGE,
+                    language = "kotlin",
+                    lightTheme = lightTheme,
+                    darkTheme = darkTheme,
+                )
+            }
+        }
+    }
+}

--- a/microbenchmark/src/androidTest/java/dev/hossain/benchmark/ShikiAnnotationBenchmark.kt
+++ b/microbenchmark/src/androidTest/java/dev/hossain/benchmark/ShikiAnnotationBenchmark.kt
@@ -1,0 +1,113 @@
+package dev.hossain.benchmark
+
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.hossain.shiki.model.DualToken
+import dev.hossain.shiki.model.HighlightDualResponse
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ShikiAnnotationBenchmark {
+
+    @get:Rule
+    val benchmarkRule = BenchmarkRule()
+
+    private lateinit var smallResponse: HighlightDualResponse
+    private lateinit var largeResponse: HighlightDualResponse
+
+    @Before
+    fun setup() {
+        smallResponse = buildMockDualResponse(lineCount = 20, tokensPerLine = 5)
+        largeResponse = buildMockDualResponse(lineCount = 200, tokensPerLine = 8)
+    }
+
+    @Test
+    fun buildAnnotatedString_small_dark() {
+        benchmarkRule.measureRepeated {
+            buildAnnotatedStringFromDualResponse(smallResponse, isDark = true)
+        }
+    }
+
+    @Test
+    fun buildAnnotatedString_small_light() {
+        benchmarkRule.measureRepeated {
+            buildAnnotatedStringFromDualResponse(smallResponse, isDark = false)
+        }
+    }
+
+    @Test
+    fun buildAnnotatedString_large_dark() {
+        benchmarkRule.measureRepeated {
+            buildAnnotatedStringFromDualResponse(largeResponse, isDark = true)
+        }
+    }
+
+    @Test
+    fun buildAnnotatedString_large_light() {
+        benchmarkRule.measureRepeated {
+            buildAnnotatedStringFromDualResponse(largeResponse, isDark = false)
+        }
+    }
+
+    private fun buildAnnotatedStringFromDualResponse(
+        response: HighlightDualResponse,
+        isDark: Boolean,
+    ): AnnotatedString =
+        buildAnnotatedString {
+            response.tokens.forEachIndexed { lineIndex, line ->
+                line.forEach { token ->
+                    val hex = if (isDark) token.darkColor else token.lightColor
+                    val color = parseHexColor(hex)
+                    withStyle(SpanStyle(color = color)) {
+                        append(token.text)
+                    }
+                }
+                if (lineIndex < response.tokens.lastIndex) {
+                    append("\n")
+                }
+            }
+        }
+
+    private fun parseHexColor(hex: String): Color {
+        val clean = hex.trimStart('#')
+        return when (clean.length) {
+            6 -> Color(android.graphics.Color.parseColor("#$clean"))
+            8 -> Color(android.graphics.Color.parseColor("#$clean"))
+            else -> Color.Unspecified
+        }
+    }
+
+    private fun buildMockDualResponse(
+        lineCount: Int,
+        tokensPerLine: Int,
+    ): HighlightDualResponse {
+        val keywords = listOf("val ", "fun ", "class ", "import ", "return ")
+        val colors = listOf("#569CD6", "#DCDCAA", "#D4D4D4", "#CE9178", "#4EC9B0")
+        val lightColors = listOf("#0000FF", "#795E26", "#000000", "#A31515", "#267F99")
+
+        val tokens = (0 until lineCount).map { lineIdx ->
+            (0 until tokensPerLine).map { tokenIdx ->
+                DualToken(
+                    text = keywords[tokenIdx % keywords.size] + "token${lineIdx}_$tokenIdx ",
+                    darkColor = colors[tokenIdx % colors.size],
+                    lightColor = lightColors[tokenIdx % lightColors.size],
+                )
+            }
+        }
+        return HighlightDualResponse(
+            language = "kotlin",
+            darkTheme = "one-dark-pro",
+            lightTheme = "github-light",
+            tokens = tokens,
+        )
+    }
+}

--- a/microbenchmark/src/androidTest/java/dev/hossain/benchmark/TextMateGrammarLoadBenchmark.kt
+++ b/microbenchmark/src/androidTest/java/dev/hossain/benchmark/TextMateGrammarLoadBenchmark.kt
@@ -1,0 +1,99 @@
+package dev.hossain.benchmark
+
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import dev.textmate.grammar.Grammar
+import dev.textmate.grammar.raw.GrammarReader
+import dev.textmate.regex.JoniOnigLib
+import dev.textmate.theme.ThemeReader
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TextMateGrammarLoadBenchmark {
+
+    @get:Rule
+    val benchmarkRule = BenchmarkRule()
+
+    private val context get() = InstrumentationRegistry.getInstrumentation().context
+
+    @Test
+    fun loadKotlinGrammar() {
+        val onigLib = JoniOnigLib()
+        benchmarkRule.measureRepeated {
+            context.assets.open("grammars/kotlin.tmLanguage.json").use { stream ->
+                val raw = GrammarReader.readGrammar(stream)
+                Grammar(raw.scopeName, raw, onigLib)
+            }
+        }
+    }
+
+    @Test
+    fun loadPythonGrammar() {
+        val onigLib = JoniOnigLib()
+        benchmarkRule.measureRepeated {
+            context.assets.open("grammars/python.tmLanguage.json").use { stream ->
+                val raw = GrammarReader.readGrammar(stream)
+                Grammar(raw.scopeName, raw, onigLib)
+            }
+        }
+    }
+
+    @Test
+    fun loadJsonGrammar() {
+        val onigLib = JoniOnigLib()
+        benchmarkRule.measureRepeated {
+            context.assets.open("grammars/JSON.tmLanguage.json").use { stream ->
+                val raw = GrammarReader.readGrammar(stream)
+                Grammar(raw.scopeName, raw, onigLib)
+            }
+        }
+    }
+
+    @Test
+    fun loadJavaScriptGrammar() {
+        val onigLib = JoniOnigLib()
+        benchmarkRule.measureRepeated {
+            context.assets.open("grammars/JavaScript.tmLanguage.json").use { stream ->
+                val raw = GrammarReader.readGrammar(stream)
+                Grammar(raw.scopeName, raw, onigLib)
+            }
+        }
+    }
+
+    @Test
+    fun loadDarkPlusTheme() {
+        benchmarkRule.measureRepeated {
+            context.assets.open("themes/dark_vs.json").use { base ->
+                context.assets.open("themes/dark_plus.json").use { overlay ->
+                    ThemeReader.readTheme(base, overlay)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun loadOneDarkProTheme() {
+        benchmarkRule.measureRepeated {
+            context.assets.open("themes/dark_vs.json").use { base ->
+                context.assets.open("themes/one_dark_pro.json").use { overlay ->
+                    ThemeReader.readTheme(base, overlay)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun loadMonokaiTheme() {
+        benchmarkRule.measureRepeated {
+            context.assets.open("themes/dark_vs.json").use { base ->
+                context.assets.open("themes/monokai.json").use { overlay ->
+                    ThemeReader.readTheme(base, overlay)
+                }
+            }
+        }
+    }
+}

--- a/microbenchmark/src/androidTest/java/dev/hossain/benchmark/TextMateHighlightBenchmark.kt
+++ b/microbenchmark/src/androidTest/java/dev/hossain/benchmark/TextMateHighlightBenchmark.kt
@@ -1,0 +1,127 @@
+package dev.hossain.benchmark
+
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import dev.textmate.compose.CodeHighlighter
+import dev.textmate.grammar.Grammar
+import dev.textmate.grammar.raw.GrammarReader
+import dev.textmate.regex.JoniOnigLib
+import dev.textmate.theme.Theme
+import dev.textmate.theme.ThemeReader
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TextMateHighlightBenchmark {
+
+    @get:Rule
+    val benchmarkRule = BenchmarkRule()
+
+    private lateinit var kotlinGrammar: Grammar
+    private lateinit var pythonGrammar: Grammar
+    private lateinit var jsonGrammar: Grammar
+    private lateinit var jsGrammar: Grammar
+    private lateinit var darkTheme: Theme
+    private lateinit var lightTheme: Theme
+    private lateinit var oneDarkProTheme: Theme
+
+    @Before
+    fun setup() {
+        val context = InstrumentationRegistry.getInstrumentation().context
+        val assets = context.assets
+        val onigLib = JoniOnigLib()
+
+        kotlinGrammar = assets.open("grammars/kotlin.tmLanguage.json").use { stream ->
+            val raw = GrammarReader.readGrammar(stream)
+            Grammar(raw.scopeName, raw, onigLib)
+        }
+        pythonGrammar = assets.open("grammars/python.tmLanguage.json").use { stream ->
+            val raw = GrammarReader.readGrammar(stream)
+            Grammar(raw.scopeName, raw, onigLib)
+        }
+        jsonGrammar = assets.open("grammars/JSON.tmLanguage.json").use { stream ->
+            val raw = GrammarReader.readGrammar(stream)
+            Grammar(raw.scopeName, raw, onigLib)
+        }
+        jsGrammar = assets.open("grammars/JavaScript.tmLanguage.json").use { stream ->
+            val raw = GrammarReader.readGrammar(stream)
+            Grammar(raw.scopeName, raw, onigLib)
+        }
+
+        darkTheme = assets.open("themes/dark_vs.json").use { base ->
+            assets.open("themes/dark_plus.json").use { overlay ->
+                ThemeReader.readTheme(base, overlay)
+            }
+        }
+        lightTheme = assets.open("themes/light_vs.json").use { base ->
+            assets.open("themes/light_plus.json").use { overlay ->
+                ThemeReader.readTheme(base, overlay)
+            }
+        }
+        oneDarkProTheme = assets.open("themes/dark_vs.json").use { base ->
+            assets.open("themes/one_dark_pro.json").use { overlay ->
+                ThemeReader.readTheme(base, overlay)
+            }
+        }
+    }
+
+    @Test
+    fun highlightKotlin_small() {
+        benchmarkRule.measureRepeated {
+            CodeHighlighter(kotlinGrammar, darkTheme).highlight(BenchmarkCodeSamples.KOTLIN)
+        }
+    }
+
+    @Test
+    fun highlightKotlin_medium() {
+        benchmarkRule.measureRepeated {
+            CodeHighlighter(kotlinGrammar, darkTheme).highlight(BenchmarkCodeSamples.KOTLIN_MEDIUM)
+        }
+    }
+
+    @Test
+    fun highlightKotlin_large() {
+        benchmarkRule.measureRepeated {
+            CodeHighlighter(kotlinGrammar, darkTheme).highlight(BenchmarkCodeSamples.KOTLIN_LARGE)
+        }
+    }
+
+    @Test
+    fun highlightPython_small() {
+        benchmarkRule.measureRepeated {
+            CodeHighlighter(pythonGrammar, darkTheme).highlight(BenchmarkCodeSamples.PYTHON)
+        }
+    }
+
+    @Test
+    fun highlightJson_small() {
+        benchmarkRule.measureRepeated {
+            CodeHighlighter(jsonGrammar, darkTheme).highlight(BenchmarkCodeSamples.JSON)
+        }
+    }
+
+    @Test
+    fun highlightJavaScript_small() {
+        benchmarkRule.measureRepeated {
+            CodeHighlighter(jsGrammar, darkTheme).highlight(BenchmarkCodeSamples.JAVASCRIPT)
+        }
+    }
+
+    @Test
+    fun highlightKotlin_lightTheme() {
+        benchmarkRule.measureRepeated {
+            CodeHighlighter(kotlinGrammar, lightTheme).highlight(BenchmarkCodeSamples.KOTLIN)
+        }
+    }
+
+    @Test
+    fun highlightKotlin_oneDarkPro() {
+        benchmarkRule.measureRepeated {
+            CodeHighlighter(kotlinGrammar, oneDarkProTheme).highlight(BenchmarkCodeSamples.KOTLIN)
+        }
+    }
+}

--- a/microbenchmark/src/main/AndroidManifest.xml
+++ b/microbenchmark/src/main/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity
+            android:name="dev.hossain.benchmark.BenchmarkActivity"
+            android:exported="false" />
+    </application>
+
+</manifest>

--- a/microbenchmark/src/main/java/dev/hossain/benchmark/BenchmarkActivity.kt
+++ b/microbenchmark/src/main/java/dev/hossain/benchmark/BenchmarkActivity.kt
@@ -1,0 +1,6 @@
+package dev.hossain.benchmark
+
+import android.app.Activity
+
+/** Minimal Activity used by [ComposeHighlightBenchmark] to provide a WebView-capable context. */
+class BenchmarkActivity : Activity()

--- a/scripts/benchmark_report.py
+++ b/scripts/benchmark_report.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+Parse AndroidX Benchmark JSON output and generate a Markdown comparison report.
+
+Usage:
+    python3 scripts/benchmark_report.py [path_to_json]
+
+If no path is given, searches the default Gradle output directory.
+"""
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def find_benchmark_json() -> Path | None:
+    """Find the benchmark JSON in the default Gradle output directory."""
+    base = Path("microbenchmark/build/outputs/connected_android_test_additional_output")
+    if not base.exists():
+        return None
+    # Look for files containing benchmark data
+    for f in sorted(base.rglob("*benchmarkData.json"), reverse=True):
+        try:
+            data = json.loads(f.read_text())
+            if "benchmarks" in data:
+                return f
+        except (json.JSONDecodeError, KeyError):
+            continue
+    # Fallback: any JSON with benchmarks key
+    for f in sorted(base.rglob("*.json"), reverse=True):
+        try:
+            data = json.loads(f.read_text())
+            if "benchmarks" in data:
+                return f
+        except (json.JSONDecodeError, KeyError):
+            continue
+    return None
+
+
+def parse_benchmark_file(path: Path) -> tuple[list[dict], dict]:
+    """Parse benchmark JSON and return structured results + context."""
+    data = json.loads(path.read_text())
+
+    results = []
+    for bench in data.get("benchmarks", []):
+        name = bench["name"]
+        class_name = bench["className"].split(".")[-1]
+        metrics = bench.get("metrics", {})
+        time_ns = metrics.get("timeNs", {})
+
+        results.append({
+            "class": class_name,
+            "name": name,
+            "median_ns": time_ns.get("median", 0),
+            "min_ns": time_ns.get("minimum", 0),
+            "max_ns": time_ns.get("maximum", 0),
+            "runs": time_ns.get("runs", []),
+            "iterations": bench.get("repeatIterations", 0),
+            "warmup": bench.get("warmupIterations", 0),
+        })
+    return results, data.get("context", {})
+
+
+def ns_to_ms(ns: float) -> float:
+    return ns / 1_000_000
+
+
+def generate_markdown(results: list[dict], context: dict) -> str:
+    """Generate a Markdown report from benchmark results."""
+    lines = []
+    lines.append("# Benchmark Results\n")
+
+    # Device info
+    build = context.get("build", {})
+    lines.append("## Device Info\n")
+    lines.append(f"| Property | Value |")
+    lines.append(f"|----------|-------|")
+    lines.append(f"| Device | {build.get('brand', '?')} {build.get('model', '?')} |")
+    lines.append(f"| API Level | {build.get('version', {}).get('sdk', '?')} |")
+    lines.append(f"| CPU Cores | {context.get('cpuCoreCount', '?')} |")
+    lines.append(f"| CPU Max Freq | {context.get('cpuMaxFreqHz', 0) / 1_000_000_000:.2f} GHz |")
+    lines.append(f"| CPU Locked | {context.get('cpuLocked', '?')} |")
+    lines.append(f"| RAM | {context.get('memTotalBytes', 0) / (1024**3):.1f} GB |")
+    lines.append("")
+
+    # Group by class
+    grouped = defaultdict(list)
+    for r in results:
+        grouped[r["class"]].append(r)
+
+    # Friendly class names
+    class_descriptions = {
+        "TextMateHighlightBenchmark": "TextMate — Code Highlighting",
+        "TextMateGrammarLoadBenchmark": "TextMate — Grammar & Theme Loading",
+        "ShikiAnnotationBenchmark": "Shiki — AnnotatedString Building",
+        "ComposeHighlightBenchmark": "Compose Highlight — WebView JS Bridge",
+    }
+
+    for class_name, benchmarks in grouped.items():
+        title = class_descriptions.get(class_name, class_name)
+        lines.append(f"## {title}\n")
+        lines.append("| Benchmark | Median (ms) | Min (ms) | Max (ms) | Iterations |")
+        lines.append("|-----------|:-----------:|:-------:|:-------:|:---------:|")
+        for b in sorted(benchmarks, key=lambda x: x["median_ns"]):
+            lines.append(
+                f"| `{b['name']}` "
+                f"| {ns_to_ms(b['median_ns']):.2f} "
+                f"| {ns_to_ms(b['min_ns']):.2f} "
+                f"| {ns_to_ms(b['max_ns']):.2f} "
+                f"| {b['iterations']} |"
+            )
+        lines.append("")
+
+    # Cross-library comparison summary (if all 3 have Kotlin benchmarks)
+    kotlin_results = {}
+    for r in results:
+        if "kotlin" in r["name"].lower() and "small" in r["name"].lower():
+            kotlin_results[r["class"]] = r
+        elif "kotlin" in r["name"].lower() and "bothThemes" in r["name"] and "large" not in r["name"].lower():
+            kotlin_results[r["class"]] = r
+
+    if len(kotlin_results) >= 2:
+        lines.append("## Cross-Library Comparison (Kotlin, small sample)\n")
+        lines.append("| Library | Median (ms) | Notes |")
+        lines.append("|---------|:-----------:|-------|")
+        for cls, r in sorted(kotlin_results.items(), key=lambda x: x[1]["median_ns"]):
+            lib_name = class_descriptions.get(cls, cls).split(" — ")[0]
+            lines.append(f"| {lib_name} | {ns_to_ms(r['median_ns']):.2f} | `{r['name']}` |")
+        lines.append("")
+
+    lines.append("---\n")
+    lines.append("*Generated by `scripts/benchmark_report.py`*\n")
+
+    return "\n".join(lines)
+
+
+def main():
+    if len(sys.argv) > 1:
+        path = Path(sys.argv[1])
+    else:
+        path = find_benchmark_json()
+
+    if path is None or not path.exists():
+        print("ERROR: No benchmark JSON found.", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("Run benchmarks first:", file=sys.stderr)
+        print("  ./gradlew :microbenchmark:connectedReleaseAndroidTest", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("Or specify the JSON path directly:", file=sys.stderr)
+        print("  python3 scripts/benchmark_report.py path/to/benchmarkData.json", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Reading: {path}", file=sys.stderr)
+    results, context = parse_benchmark_file(path)
+
+    if not results:
+        print("ERROR: No benchmark results found in the JSON file.", file=sys.stderr)
+        sys.exit(1)
+
+    report = generate_markdown(results, context)
+
+    # Print to stdout
+    print(report)
+
+    # Also write to file
+    output_path = Path("BENCHMARK_RESULTS.md")
+    output_path.write_text(report)
+    print(f"\nReport written to {output_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,3 +22,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "Syntax Highlight"
 include(":app")
+include(":microbenchmark")


### PR DESCRIPTION
## Add AndroidX Microbenchmark module for syntax highlighting libraries

### Summary

- Add a `:microbenchmark` module using AndroidX Benchmark (benchmark-junit4:1.4.1) to measure the performance of all three syntax highlighting approaches
- Benchmarks cover kotlin-textmate (CPU tokenization), Shiki SDK (AnnotatedString building), and compose-highlight (WebView JS bridge) across multiple languages and code sizes
- Include a Python report script that parses benchmark JSON output into a Markdown comparison table

### What's Benchmarked

| Class | Library | Operations |
|-------|---------|-----------|
| `TextMateHighlightBenchmark` | kotlin-textmate | `CodeHighlighter.highlight()` — 4 languages × 3 sizes (small/medium/~1000 lines) × 3 themes |
| `TextMateGrammarLoadBenchmark` | kotlin-textmate | Grammar parsing + theme loading from assets |
| `ShikiAnnotationBenchmark` | Shiki SDK | Token list → `AnnotatedString` conversion (small + large) |
| `ComposeHighlightBenchmark` | compose-highlight | `HighlightEngine.highlightBothThemes()` via ActivityScenario (WebView JS round-trip) |

### How to Run

```bash
# Full run on physical device (accurate results)
./gradlew :microbenchmark:connectedReleaseAndroidTest

# Dry-run on emulator (verify tests pass)
./gradlew :microbenchmark:connectedReleaseAndroidTest \
  -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.dryRunMode.enable=true

# Generate Markdown report from results
python3 scripts/benchmark_report.py
```

### Test plan

- [x] `./gradlew :microbenchmark:assembleReleaseAndroidTest` compiles successfully
- [x] All 25 benchmarks pass in dry-run mode on emulator
- [x] `./gradlew assembleDebug` still builds the app module without regressions
- [ ] Run on physical device for publishable results (optional for merge)
