### PR TITLE
chore: upgrade compose-highlight to 0.21.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ androidxTestRunner = "1.6.2"
 benchmarkJunit4 = "1.4.1"
 
 # https://github.com/hossain-khan/android-compose-highlight
-composeHighlight = "0.20.0"
+composeHighlight = "0.21.0"
 
 # https://github.com/ivan-magda/kotlin-textmate
 kotlinTextmate = "0.1.0"


### PR DESCRIPTION
## Overview

Upgrades the `compose-highlight` library from **0.20.0** to **0.21.0**.

## What's New in 0.21.0

### ⚠️ Breaking Changes

- **Slot parameter renames** (Material 3 compliance):
  - `languageLabelContent` → `languageLabel`
  - `copyButtonContent` → `copyButton`
  - `placeholder` unchanged

- **`CodeBlockStyle` constructor** gains `fallbackBackgroundColor` and `fallbackTextColor` fields
  - Binary-incompatible for pre-compiled consumers
  - Source-compatible with default values

### ✨ New Features

- **Configurable fallback colors** when a theme's CSS has no `.hljs` base rule
  - `CodeBlockStyle.fallbackBackgroundColor` / `fallbackTextColor`
  - Matching constants in `SyntaxHighlightedCodeDefaults`
  - Defaults unchanged: `Color(0xFF1E1E1E)` / `Color(0xFFCCCCCC)`

### 🐛 Bug Fixes

- **Font-weight parsing**: Numeric values (600, 800, 900, etc.) now properly map to `FontWeight.Bold` (≥600) or `FontWeight.Normal` (<600)
- **JS error handling**: Errors in `highlightCode`/`highlightAuto`/`getLanguage` now surface as `HighlightException.JsExecutionFailed` with actual error messages instead of opaque nulls
- **Race condition**: Fixed `HighlightTheme.timedColorMap()` with `AtomicBoolean.compareAndSet` for correct timing attribution

## Testing

✅ All checks pass:
- Kotlin formatting: **PASS**
- Kotlin linting: **PASS** 
- Assembly build: **PASS**
- Unit tests: **PASS**

Note: Pre-existing Android lint errors in `Theme.kt` (API level 31 requirement) are unrelated to this upgrade.

## Changes

- Updated `gradle/libs.versions.toml`: `composeHighlight = "0.21.0"`
