### PR TITLE
Upgrade compose-highlight to 0.31.0 and kotlin-textmate to 0.2.0

### DIFF
--- a/COMPARE.md
+++ b/COMPARE.md
@@ -14,15 +14,15 @@ Code is sent in a single network request to the `/highlight/dual` endpoint, whic
 and a light theme. The client builds an `AnnotatedString` from those tokens and renders it with
 a monospace font — no grammar files or WebView needed on the device.
 
-**kotlin-textmate** (`io.github.ivan-magda:kotlin-textmate-compose:0.1.0`)  
+**kotlin-textmate** (`io.github.ivan-magda:kotlin-textmate-compose:0.2.0`)  
 Ports Microsoft's vscode-textmate engine to Kotlin/JVM. Loads `.tmLanguage.json` grammar files
 and VS Code JSON theme files from assets, then tokenizes code line-by-line using the Joni
 (Java Oniguruma) regex engine — entirely in-process, no WebView involved. Output is an
 `AnnotatedString` built directly from token scopes matched against theme rules.
 
-**compose-highlight** (`dev.hossain:compose-highlight:0.24.0`)  
+**compose-highlight** (`dev.hossain:compose-highlight:0.31.0`)  
 Runs [Highlight.js](https://highlightjs.org/) inside a single hidden WebView. Code is sent
-over a JS bridge, tokenized in JavaScript, the resulting HTML is parsed via jsoup, and CSS
+over a JS bridge, tokenized in JavaScript, the resulting HTML is parsed via a custom lightweight HTML parser, and CSS
 theme selectors are mapped to `SpanStyle`s to produce an `AnnotatedString`. All WebView
 operations are suspend functions behind a `Mutex`.
 
@@ -50,9 +50,9 @@ operations are suspend functions behind a `Mutex`.
 | **Line numbers** | Not built-in | Not built-in | `showLineNumbers = true` on `SyntaxHighlightedCode` |
 | **Shared engine** | `ShikiClient` (stateless HTTP) | No provider concept; one `Grammar` per use | `HighlightThemeProvider` shares one WebView across the subtree |
 | **Thread-safety** | Inherently safe (stateless HTTP) | `Grammar` is **not** thread-safe | `HighlightEngine` is safe via `Mutex` |
-| **Timing metrics exposed** | `requestDurationMs`, `annotationDurationMs` | `measureTimedValue` wraps `CodeHighlighter.highlight()` | `HighlightTimings` (`jsBridge`, `jsonUnescape`, `htmlParse`, `treeWalk`, `themeParse`, `total`) |
+| **Timing metrics exposed** | `requestDurationMs`, `annotationDurationMs` | `measureTimedValue` wraps `CodeHighlighter.highlight()` | `HighlightTimings` (`jsBridge`, `jsonUnescape`, `htmlParse`, `themeParse`, `total`) |
 | **Benchmarks published** | `buildAnnotatedString` only (AndroidX Microbenchmark; network RTT excluded) | Yes (AndroidX Microbenchmark, ms/snippet) | Yes (AndroidX Microbenchmark, ms/snippet) |
-| **Current version (this app)** | `sdk-1.0.5` | `0.1.0` ✓ latest | `0.19.0` ✓ latest |
+| **Current version (this app)** | `sdk-1.0.5` | `0.2.0` ✓ latest | `0.31.0` ✓ latest |
 
 ---
 

--- a/HOW_IT_WORKS.md
+++ b/HOW_IT_WORKS.md
@@ -117,7 +117,7 @@ Text(annotated, fontFamily = Monospace)
 
 ```kotlin
 // gradle/libs.versions.toml
-compose-highlight = { group = "dev.hossain", name = "compose-highlight", version = "0.24.0" }
+compose-highlight = { group = "dev.hossain", name = "compose-highlight", version = "0.31.0" }
 ```
 
 Distributed via [Maven Central](https://central.sonatype.com/artifact/dev.hossain/compose-highlight).

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,6 +28,10 @@ android {
         val apiKey = localProperties?.getProperty("SERVICE_API_KEY") ?: "MISSING-KEY"
         buildConfigField("String", "SERVICE_API_KEY", "\"$apiKey\"")
 
+        buildConfigField("String", "SHIKI_SDK_VERSION", "\"${libs.versions.shikiSdk.get()}\"")
+        buildConfigField("String", "KOTLIN_TEXTMATE_VERSION", "\"${libs.versions.kotlinTextmate.get()}\"")
+        buildConfigField("String", "COMPOSE_HIGHLIGHT_VERSION", "\"${libs.versions.composeHighlight.get()}\"")
+
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/comparison/ComparisonScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/comparison/ComparisonScreen.kt
@@ -724,7 +724,6 @@ private fun ComposeHighlightInfoCard(
                 InfoRow(label = "🌐  JS bridge", value = timings.jsBridge.toDisplayString())
                 InfoRow(label = "📝  JSON unescape", value = timings.jsonUnescape.toDisplayString())
                 InfoRow(label = "🔍  HTML parse", value = timings.htmlParse.toDisplayString())
-                InfoRow(label = "🌳  Tree walk", value = timings.treeWalk.toDisplayString())
                 if (timings.themeParse > Duration.ZERO) {
                     InfoRow(label = "🎨  Theme parse", value = timings.themeParse.toDisplayString())
                 } else {

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/composehighlight/ComposeHighlightScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/composehighlight/ComposeHighlightScreen.kt
@@ -120,7 +120,7 @@ enum class ComposeHighlightThemePair(
  *    time and would re-highlight on every toggle.
  * 2. **Per-stage timing metrics** — the screen displays a breakdown of
  *    [dev.hossain.highlight.engine.HighlightTimings] fields (`jsBridge`, `jsonUnescape`,
- *    `htmlParse`, `treeWalk`, `themeParse`, `total`) sourced from `themedResult?.timings`.
+ *    `htmlParse`, `themeParse`, `total`) sourced from `themedResult?.timings`.
  *    `SyntaxHighlightedCode` does not expose internal timing data to callers.
  * 3. **Custom layout control** — the screen combines language + theme dropdowns, a scrollable
  *    code block, and the metrics row in a single `Column`. Writing the `Text` directly avoids
@@ -296,8 +296,8 @@ private fun ReadyContent(
     // SyntaxHighlightedCode composable for three reasons:
     //  1. A single JS call produces both light and dark AnnotatedStrings so that theme
     //     toggling is instantaneous — no re-highlighting on each switch.
-    //  2. themedResult.timings exposes per-stage HighlightTimings (jsBridge, htmlParse,
-    //     treeWalk, etc.) for the metrics row; SyntaxHighlightedCode does not surface these.
+    //  2. themedResult.timings exposes per-stage HighlightTimings (jsBridge, jsonUnescape,
+    //     htmlParse, themeParse, total) for the metrics row; SyntaxHighlightedCode does not surface these.
     //  3. The screen owns its own layout (dropdowns + code block + metrics row) which
     //     is simpler to compose than overriding SyntaxHighlightedCode's built-in chrome.
     val themedResult by rememberHighlightedCodeBothThemes(
@@ -514,7 +514,6 @@ private fun ComposeHighlightMetricsRow(
                 TimingLabel("JS", timings.jsBridge)
                 TimingLabel("unescape", timings.jsonUnescape)
                 TimingLabel("HTML", timings.htmlParse)
-                TimingLabel("walk", timings.treeWalk)
                 if (timings.themeParse > Duration.ZERO) {
                     TimingLabel("theme", timings.themeParse)
                 } else {

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/home/HomeScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/home/HomeScreen.kt
@@ -1,6 +1,8 @@
 package dev.hossain.syntaxhighlight.circuit.home
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -142,6 +144,7 @@ private data class HighlightApproach(
     val subtitle: String,
     val iconRes: Int,
     val event: HomeScreen.Event,
+    val version: String? = null,
 )
 
 // Constant list — hoisted out of the composable to avoid allocation on every recomposition.
@@ -155,6 +158,7 @@ private val approaches =
                     "the app builds an AnnotatedString and renders it natively.",
             iconRes = R.drawable.cloud_24dp,
             event = HomeScreen.Event.OpenShikiHighlight,
+            version = "sdk-1.0.5",
         ),
         HighlightApproach(
             title = "Kotlin TextMate",
@@ -163,6 +167,7 @@ private val approaches =
                     "No network required — grammars and themes are bundled in the app assets.",
             iconRes = R.drawable.cloud_off_24dp,
             event = HomeScreen.Event.OpenTextMateHighlight,
+            version = "0.2.0",
         ),
         HighlightApproach(
             title = "Compose Highlight",
@@ -171,6 +176,7 @@ private val approaches =
                     "190+ languages with no grammar files to maintain — just drop in the library.",
             iconRes = R.drawable.cloud_off_24dp,
             event = HomeScreen.Event.OpenComposeHighlight,
+            version = "0.31.0",
         ),
         HighlightApproach(
             title = "Compare All Highlights",
@@ -257,6 +263,23 @@ private fun ApproachCard(
                     style = MaterialTheme.typography.titleLarge,
                     color = MaterialTheme.colorScheme.onPrimaryContainer,
                 )
+                if (approach.version != null) {
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Box(
+                        modifier =
+                            Modifier
+                                .background(
+                                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.15f),
+                                    shape = MaterialTheme.shapes.extraSmall,
+                                ).padding(horizontal = 6.dp, vertical = 2.dp),
+                    ) {
+                        Text(
+                            text = approach.version,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        )
+                    }
+                }
             }
             Spacer(modifier = Modifier.height(6.dp))
             Text(

--- a/app/src/main/java/dev/hossain/syntaxhighlight/circuit/home/HomeScreen.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/circuit/home/HomeScreen.kt
@@ -39,6 +39,7 @@ import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuitx.overlays.BottomSheetOverlay
+import dev.hossain.syntaxhighlight.BuildConfig
 import dev.hossain.syntaxhighlight.R
 import dev.hossain.syntaxhighlight.circuit.comparison.ComparisonScreen
 import dev.hossain.syntaxhighlight.circuit.composehighlight.ComposeHighlightScreen
@@ -158,7 +159,7 @@ private val approaches =
                     "the app builds an AnnotatedString and renders it natively.",
             iconRes = R.drawable.cloud_24dp,
             event = HomeScreen.Event.OpenShikiHighlight,
-            version = "sdk-1.0.5",
+            version = BuildConfig.SHIKI_SDK_VERSION,
         ),
         HighlightApproach(
             title = "Kotlin TextMate",
@@ -167,7 +168,7 @@ private val approaches =
                     "No network required — grammars and themes are bundled in the app assets.",
             iconRes = R.drawable.cloud_off_24dp,
             event = HomeScreen.Event.OpenTextMateHighlight,
-            version = "0.2.0",
+            version = BuildConfig.KOTLIN_TEXTMATE_VERSION,
         ),
         HighlightApproach(
             title = "Compose Highlight",
@@ -176,7 +177,7 @@ private val approaches =
                     "190+ languages with no grammar files to maintain — just drop in the library.",
             iconRes = R.drawable.cloud_off_24dp,
             event = HomeScreen.Event.OpenComposeHighlight,
-            version = "0.31.0",
+            version = BuildConfig.COMPOSE_HIGHLIGHT_VERSION,
         ),
         HighlightApproach(
             title = "Compare All Highlights",

--- a/app/src/main/java/dev/hossain/syntaxhighlight/ui/theme/Theme.kt
+++ b/app/src/main/java/dev/hossain/syntaxhighlight/ui/theme/Theme.kt
@@ -34,6 +34,7 @@ fun SyntaxHighlightAppTheme(
         when {
             dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
                 val context = LocalContext.current
+                @Suppress("NewApi")
                 if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
             }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Android SDK versions
 # https://developer.android.com/about/versions
-compileSdk = "36"
+compileSdk = "37"
 targetSdk = "36"
 minSdk = "28"
 
@@ -38,10 +38,10 @@ androidxTestRunner = "1.6.2"
 benchmarkJunit4 = "1.4.1"
 
 # https://github.com/hossain-khan/android-compose-highlight
-composeHighlight = "0.24.0"
+composeHighlight = "0.31.0"
 
 # https://github.com/ivan-magda/kotlin-textmate
-kotlinTextmate = "0.1.0"
+kotlinTextmate = "0.2.0"
 
 # https://github.com/hossain-khan/shiki-token-service/blob/main/sdk/README.md
 shikiSdk = "sdk-1.0.5"


### PR DESCRIPTION
This PR upgrades key on-device syntax highlighting libraries to their latest versions and updates the app configuration to support them.

### Dependency Updates

* **`compose-highlight`** (`0.24.0` ➔ `0.31.0`):
  * **Custom HTML Parser:** Replaced Jsoup with a custom lightweight HTML parser, resulting in a **5.49% shrink in dex size** and a **1.27× - 1.97× speedup** in parsing.
  * **Timing metrics:** The separate `treeWalk` timing stage was eliminated since HTML styling is now performed in a single pass.
  * **Scroll-state hoisting:** Added scroll support and scroll-state hoisting to `SyntaxHighlightedCode` and `SyntaxHighlightedTextEditor`.
  * **Preview stability:** Fixed WebView initialization inside Compose Previews.
  * **Hex Color Parser:** Fixed parsing of 8-digit CSS hex colors (`#RRGGBBAA`).
* **`kotlin-textmate`** (`0.1.0` ➔ `0.2.0`):
  * **Minification support:** Shipped ProGuard keep rules for theme/grammar JSON serialization so minified builds (`isMinifyEnabled = true`) no longer crash.
  * **License attribution:** Added `THIRD-PARTY-NOTICES.md` for VS Code grammar/theme files.
  * **API stability:** Configured binary-compatibility validator.
* **`compileSdk`** (Bumped from `36` to `37`):
  * Required to support the newer libraries and their transitive dependencies (e.g. `androidx.core:core-ktx:1.19.0`).

### Code Changes

* **Removed `treeWalk` timings:**
  * Updated [ComparisonScreen.kt](file:///Users/hossain/dev/repos/android-apps/android-syntax-highlighter-compose/app/src/main/java/dev/hossain/syntaxhighlight/circuit/comparison/ComparisonScreen.kt) and [ComposeHighlightScreen.kt](file:///Users/hossain/dev/repos/android-apps/android-syntax-highlighter-compose/app/src/main/java/dev/hossain/syntaxhighlight/circuit/composehighlight/ComposeHighlightScreen.kt) to remove references to the obsolete `treeWalk` duration property from `HighlightTimings`.
* **Updated comparison docs:**
  * Adjusted [COMPARE.md](file:///Users/hossain/dev/repos/android-apps/android-syntax-highlighter-compose/COMPARE.md) and [HOW_IT_WORKS.md](file:///Users/hossain/dev/repos/android-apps/android-syntax-highlighter-compose/HOW_IT_WORKS.md) to reflect the updated library versions, timings, and HTML parser details.
